### PR TITLE
Set method of Request in builder pattern

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -266,6 +266,16 @@ impl<'a> Request<'a> {
     }
 
     ///Changes request's method
+    pub fn method<T>(&mut self, method: T) -> &mut Self
+    where
+        Method: From<T>,
+    {
+        self.inner.method(method);
+
+        self
+    }
+
+    ///Changes request's method
     pub fn set_method<T>(&mut self, method: T)
     where
         Method: From<T>,


### PR DESCRIPTION
This also does not yet have any tests. I'm kinda solving my own issues with these two PRs, but I thought I'd share the changes in case they have a place in the crate.

One thing to note is that I chose to create a new method `fn method` as opposed to overwriting a method to ensure compatibility.