### PR TITLE
Add the port to the Host header when required

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -186,7 +186,7 @@ impl Headers {
     pub fn default_http(uri: &Uri) -> Headers {
         let mut headers = Headers::with_capacity(4);
 
-        headers.insert("Host", uri.host().unwrap_or(""));
+        headers.insert("Host", &uri.host_header().unwrap_or(String::new()));
         headers.insert("Referer", uri);
 
         headers

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -69,6 +69,21 @@ impl Uri {
         }
     }
 
+    ///Returns host of this `Uri` to use in a header.
+    pub fn host_header(&self) -> Option<String> {
+        match self.authority {
+            Some(ref a) => match (a.host(), a.port()) {
+                (Some(h), Some(p)) => Some(match *p {
+                    HTTP_PORT | HTTPS_PORT => h.to_string(),
+                    _ => format!("{}:{}", h, p),
+                }),
+                (Some(h), None) => Some(h.to_string()),
+                _ => None,
+            },
+            None => None,
+        }
+    }
+
     ///Returns port of this `Uri`
     pub fn port(&self) -> &Option<u16> {
         match &self.authority {


### PR DESCRIPTION
Both RFC 2616 and RFC 7230 requires the `Host` header field to contain the port number when it not the default one. Although most web servers can handle it correctly, it is known to cause invalid URLs if the web application uses the `Host` header to generate absolute links.

https://tools.ietf.org/html/rfc2616#section-14.23
https://tools.ietf.org/html/rfc7230#section-5.4