### PR TITLE
using the content-length of the response when the header exists

### DIFF
--- a/examples/request_builder_get.rs
+++ b/examples/request_builder_get.rs
@@ -1,9 +1,12 @@
 use http_req::{request::RequestBuilder, tls, uri::Uri};
 use std::net::TcpStream;
+use std::fs::File;
+use http_req::request::Method;
+use std::io::Read;
 
 fn main() {
     //Parse uri and assign it to variable `addr`
-    let addr: Uri = "https://doc.rust-lang.org/".parse().unwrap();
+    let addr: Uri = "https://qualiflps.services-ps.ameli.fr/lps".parse().unwrap();
 
     //Connect to remote host
     let stream = TcpStream::connect((addr.host().unwrap(), addr.corr_port())).unwrap();
@@ -17,11 +20,34 @@ fn main() {
     let mut writer = Vec::new();
 
     //Add header `Connection: Close`
-    let response = RequestBuilder::new(&addr)
-        .header("Connection", "Close")
-        .send(&mut stream, &mut writer)
+
+
+
+    let mut f = File::open("/Users/cedric.couton/dev/billeo-engine/WSTest.xml").unwrap();
+    let mut content = Vec::new();
+    f.read_to_end(&mut content).unwrap();
+    let content = content.as_slice();
+    println!("content length : {}", content.len());
+
+    let mut request_builder = RequestBuilder::new(&addr);
+    let request= request_builder.method(Method::POST)
+        //.header("Connection", "Close")
+        //.header("Host", "qualiflps.services-ps.ameli.fr")
+        .header("Content-Length", &format!("{}", 7062))
+        .header("User-Agent", "reqwest/0.10.0-alpha.2")
+        .header("accept", "*/*")
+    //"user-agent": "reqwest/0.10.0-alpha.2", "accept": "*/*"
+        //.header("Content-Type", "application/soap+xml")
+        .body(content);
+
+    println!("request : {}", &String::from_utf8_lossy(&request.clone().parse_msg()));
+
+
+     let response =   request.send(&mut stream, &mut writer)
         .unwrap();
 
+
     println!("Status: {} {}", response.status_code(), response.reason());
-    //println!("{}", String::from_utf8_lossy(&writer));
+    //println!("{:?}", writer);
+    println!("{}", String::from_utf8_lossy(&writer));
 }


### PR DESCRIPTION
Hi,

When exists a header with Content-Length, it is now used to copy stream data to response.

Best regards.