### PR TITLE
fix use of deprecated item 'std::error::Error::description'

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 //!error system
-use std::{error::Error as StdErr, fmt, io, num, str};
+use std::{fmt, io, num, str};
 
 #[derive(Debug, PartialEq)]
 pub enum ParseErr {
@@ -14,15 +14,9 @@ pub enum ParseErr {
 
 impl fmt::Display for ParseErr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ParseErr: {}", self.description())
-    }
-}
-
-impl StdErr for ParseErr {
-    fn description(&self) -> &str {
         use self::ParseErr::*;
 
-        match self {
+        let err = match self {
             Utf8(_) => "invalid character",
             Int(_) => "cannot parse number",
             Invalid => "invalid value",
@@ -30,7 +24,8 @@ impl StdErr for ParseErr {
             StatusErr => "status line contains invalid values",
             HeadersErr => "headers contain invalid values",
             UriErr => "uri contains invalid characters",
-        }
+        };
+        write!(f, "ParseErr: {}", err)
     }
 }
 
@@ -55,19 +50,14 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Error: {}", self.description())
-    }
-}
-
-impl StdErr for Error {
-    fn description(&self) -> &str {
         use self::Error::*;
 
-        match self {
+        let err = match self {
             IO(_) => "IO error",
-            Parse(e) => e.description(),
             Tls => "TLS error",
-        }
+            Parse(err) => return err.fmt(f),
+        };
+        write!(f, "Error: {}", err)
     }
 }
 


### PR DESCRIPTION
std::error::Error::description is deprecated since 1.41.0.
This commit implements the error messages in fmt::Display.