### PR TITLE
set 'Content-Length' automaticly

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -383,6 +383,7 @@ impl<'a> RequestBuilder<'a> {
     ///```
     pub fn body(&mut self, body: &'a [u8]) -> &mut Self {
         self.body = Some(body);
+        self.headers.insert("Content-Length", &body.len());
         self
     }
 


### PR DESCRIPTION
Set 'Content-Length' automaticly when set body into request

This setting is suit for most scenarios, and sure you can set it back to zero if needed.