### PR TITLE
Fix wrong uri resource when there is query without path 

### DIFF
--- a/src/uri.rs
+++ b/src/uri.rs
@@ -502,12 +502,13 @@ fn get_chunks<'a>(
 mod tests {
     use super::*;
 
-    const TEST_URIS: [&str; 5] = [
+    const TEST_URIS: [&str; 6] = [
         "https://user:info@foo.com:12/bar/baz?query#fragment",
         "file:///C:/Users/User/Pictures/screenshot.png",
         "https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol",
         "mailto:John.Doe@example.com",
         "https://[4b10:bbb0:0:d0::ba7:8001]:443/",
+        "http://website.com/?q=asd",
     ];
 
     const TEST_AUTH: [&str; 4] = [
@@ -692,6 +693,7 @@ mod tests {
         assert_eq!(uris[2].resource(), "/wiki/Hypertext_Transfer_Protocol");
         assert_eq!(uris[3].resource(), "John.Doe@example.com");
         assert_eq!(uris[4].resource(), "/");
+        assert_eq!(uris[5].resource(), "/?q=asd");
     }
 
     #[test]

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -1,6 +1,7 @@
 //! uri operations
 use crate::error::{Error, ParseErr};
 use std::{
+    borrow::Cow,
     convert::TryFrom,
     fmt,
     ops::{Index, Range},
@@ -228,12 +229,15 @@ impl<'a> Uri<'a> {
     ///let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
     ///assert_eq!(uri.resource(), "/bar/baz?query#fragment");
     ///```
-    pub fn resource(&self) -> &str {
-        let mut result = "/";
+    pub fn resource(&self) -> Cow<str> {
+        let mut result = Cow::from(match self.path() {
+            Some(p) => p,
+            None => "/",
+        });
 
-        for v in &[self.path, self.query, self.fragment] {
+        for v in &[self.query, self.fragment] {
             if let Some(r) = v {
-                result = &self.inner[r.start..];
+                result.to_mut().push_str(&self.inner[r.start - 1..]);
                 break;
             }
         }


### PR DESCRIPTION
According to the RFC 3986, paths can never be None unless the URI is opaque.
Since HTTP URLs are not opaque, it is ok to always inclued path in `resource` as "/" even when it's not given.

This fixes the test cases I added. A bad request was being sent before these changes.