### PR TITLE
Fix for incorrect Content-Length: 0 handling

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -510,10 +510,10 @@ impl<'a> RequestBuilder<'a> {
             let deadline = Instant::now() + timeout;
             copy_with_timeout(stream, writer, deadline)?;
         } else {
-            let num_bytes = res.content_len().unwrap_or(0);
-
-            if num_bytes > 0 {
-                copy_exact(stream, writer, num_bytes - body_part.len())?;
+            if let Some(num_bytes) = res.content_len() {
+                if num_bytes > 0 {
+                    copy_exact(stream, writer, num_bytes - body_part.len())?;
+                }
             } else {
                 io::copy(stream, writer)?;
             }


### PR DESCRIPTION
If the Content-Length header is set to 0, the client must not read the content from the stream, otherwise it hangs waiting for data.  Redirect responses (302, 307) usually have no content and have Content-Length: 0