### PR TITLE
V0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.11"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "http_req"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "native-tls",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "http_req"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "native-tls",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,69 @@
 version = 3
 
 [[package]]
-name = "base64"
-version = "0.21.7"
+name = "aho-corasick"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7d844e282b4b56750b2d4e893b2205581ded8709fddd2b6aa5418c150ca877"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a2c29203f6bf296d01141cc8bb9dbd5ecd4c27843f2ee0767bcd5985a927da"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.5.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
 
 [[package]]
 name = "bitflags"
@@ -25,12 +84,46 @@ name = "cc"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -47,6 +140,18 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "errno"
@@ -80,6 +185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "getrandom"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,15 +202,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "http_req"
 version = "0.11.0"
 dependencies = [
  "native-tls",
  "rustls",
  "rustls-pemfile",
+ "rustls-pki-types",
  "unicase",
  "webpki",
  "webpki-roots",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -109,10 +254,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libloading"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -125,6 +286,24 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "native-tls"
@@ -142,6 +321,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -195,10 +384,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -219,6 +424,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +466,12 @@ dependencies = [
  "untrusted",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -248,32 +488,44 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
+ "aws-lc-rs",
  "log",
- "ring",
+ "once_cell",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
  "base64",
+ "rustls-pki-types",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pki-types"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -284,16 +536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
  "windows-sys",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -320,10 +562,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -399,9 +653,24 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
 
 [[package]]
 name = "windows-sys"
@@ -475,3 +744,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,18 @@ unicase = "^2.7"
 
 [features]
 default = ["native-tls"]
-rust-tls = ["rustls", "webpki", "webpki-roots", "rustls-pemfile"]
+rust-tls = ["rustls", "rustls-pki-types", "webpki", "webpki-roots", "rustls-pemfile"]
 
 [dependencies.native-tls]
 version = "^0.2"
 optional = true
 
 [dependencies.rustls]
-version = "^0.21"
+version = "^0.23"
 optional = true
 
 [dependencies.rustls-pemfile]
-version = "^1.0"
+version = "^2.1"
 optional = true
 
 [dependencies.webpki]
@@ -34,5 +34,10 @@ version = "^0.22"
 optional = true
 
 [dependencies.webpki-roots]
-version = "^0.25"
+version = "^0.26"
+optional = true
+
+[dependencies.rustls-pki-types]
+version = "^1.7"
+features = ["alloc"]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http_req"
-version = "0.10.3"
+version = "0.11.0"
 license = "MIT"
 description = "simple and lightweight HTTP client with built-in HTTPS support"
 repository = "https://github.com/jayjamesjay/http_req"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2023 jayjamesjay
+Copyright (c) 2018-2024 jayjamesjay
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # http_req
+> [!CAUTION]
+> V0.11.0 introduces major changes to design of `RequestBuilder` and `Request`. Please review [documentation](https://docs.rs/http_req/0.11.0/http_req/) before migrating from previous versions.
+
 [![Rust](https://github.com/jayjamesjay/http_req/actions/workflows/rust.yml/badge.svg)](https://github.com/jayjamesjay/http_req/actions/workflows/rust.yml)
-[![Crates.io](https://img.shields.io/badge/crates.io-v0.10.3-orange.svg?longCache=true)](https://crates.io/crates/http_req)
-[![Docs.rs](https://docs.rs/http_req/badge.svg)](https://docs.rs/http_req/0.10.3/http_req/)
+[![Crates.io](https://img.shields.io/badge/crates.io-v0.11.0-orange.svg?longCache=true)](https://crates.io/crates/http_req)
+[![Docs.rs](https://docs.rs/http_req/badge.svg)](https://docs.rs/http_req/0.11.0/http_req/)
 
 Simple and lightweight HTTP client with built-in HTTPS support.
 
@@ -29,7 +32,7 @@ Take a look at [more examples](https://github.com/jayjamesjay/http_req/tree/mast
 In order to use `http_req` with `rustls` in your project, add the following lines to `Cargo.toml`:
 ```toml
 [dependencies]
-http_req  = {version="^0.10", default-features = false, features = ["rust-tls"]}
+http_req  = {version="^0.11", default-features = false, features = ["rust-tls"]}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # http_req
 > [!CAUTION]
-> V0.11.0 introduces major changes to design of `RequestBuilder` and `Request`. Please review [documentation](https://docs.rs/http_req/0.11.0/http_req/) before migrating from previous versions.
+> v0.11.0 introduces major changes to design of `RequestBuilder` and `Request`. Please review [documentation](https://docs.rs/http_req/0.11.0/http_req/) before migrating from previous versions.
 
 [![Rust](https://github.com/jayjamesjay/http_req/actions/workflows/rust.yml/badge.svg)](https://github.com/jayjamesjay/http_req/actions/workflows/rust.yml)
 [![Crates.io](https://img.shields.io/badge/crates.io-v0.11.0-orange.svg?longCache=true)](https://crates.io/crates/http_req)

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -26,9 +26,7 @@ fn request_send(b: &mut Bencher) {
         let uri = Uri::try_from(URI).unwrap();
         let mut writer = Vec::new();
 
-        let res = Request::new(&uri)
-            .send(&mut writer)
-            .unwrap();
+        let res = Request::new(&uri).send(&mut writer).unwrap();
 
         res
     });

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,7 +3,7 @@ extern crate http_req;
 extern crate test;
 
 use http_req::{request::Request, response::Response, uri::Uri};
-use std::{convert::TryFrom, fs::File, io::Read, time::Duration};
+use std::{convert::TryFrom, fs::File, io::Read};
 use test::Bencher;
 
 #[bench]
@@ -24,11 +24,9 @@ const URI: &str = "https://www.rust-lang.org/";
 fn request_send(b: &mut Bencher) {
     b.iter(|| {
         let uri = Uri::try_from(URI).unwrap();
-        let timeout = Some(Duration::from_secs(6));
         let mut writer = Vec::new();
 
         let res = Request::new(&uri)
-            .timeout(timeout)
             .send(&mut writer)
             .unwrap();
 

--- a/examples/chunked.rs
+++ b/examples/chunked.rs
@@ -1,0 +1,12 @@
+use http_req::request;
+
+fn main() {
+    //Sends a HTTP GET request and processes the response.
+    let mut body = Vec::new();
+    let res = request::get("https://jigsaw.w3.org/HTTP/ChunkedScript", &mut body).unwrap();
+
+    //Prints details about the response.
+    println!("Status: {} {}", res.status_code(), res.reason());
+    println!("Headers: {}", res.headers());
+    //println!("{}", String::from_utf8_lossy(&body));
+}

--- a/examples/chunked.rs
+++ b/examples/chunked.rs
@@ -1,11 +1,11 @@
 use http_req::request;
 
 fn main() {
-    //Sends a HTTP GET request and processes the response.
+    // Sends a HTTP GET request and processes the response.
     let mut body = Vec::new();
     let res = request::get("https://jigsaw.w3.org/HTTP/ChunkedScript", &mut body).unwrap();
 
-    //Prints details about the response.
+    // Prints details about the response.
     println!("Status: {} {}", res.status_code(), res.reason());
     println!("Headers: {}", res.headers());
     //println!("{}", String::from_utf8_lossy(&body));

--- a/examples/get.rs
+++ b/examples/get.rs
@@ -1,28 +1,14 @@
 use http_req::request;
-use http_req::{request::Request, response::StatusCode, uri::Uri};
-use std::convert::TryFrom;
-use std::fs::File;
 
 fn main() {
     //Container for body of a response.
-    //let mut body = Vec::new();
+    let mut body = Vec::new();
 
     //Sends a HTTP GET request and processes the response. Saves body of the response to `body` variable.
-    //let res = request::get("https://drivers.amd.com/drivers/installer/23.40/whql/amd-software-adrenalin-edition-24.5.1-minimalsetup-240514_web.exe", &mut body).unwrap();
+    let res = request::get("https://www.rust-lang.org/learn", &mut body).unwrap();
 
     //Prints details about the response.
-    //println!("Status: {} {}", res.status_code(), res.reason());
-    //println!("Headers: {}", res.headers());
+    println!("Status: {} {}", res.status_code(), res.reason());
+    println!("Headers: {}", res.headers());
     //println!("{}", String::from_utf8_lossy(&body));
-
-    let mut writer = File::create("boo.txt").unwrap();
-    let uri = Uri::try_from("https://drivers.amd.com/drivers/whql-amd-software-adrenalin-edition-24.5.1-win10-win11-may15-rdna.exe").unwrap();
-
-    let response = Request::new(&uri)
-        .header("Referer", &uri)
-        .send(&mut writer)
-        .unwrap();
-
-    println!("Status: {} {}", response.status_code(), response.reason());
-    println!("Headers: {}", response.headers());
 }

--- a/examples/get.rs
+++ b/examples/get.rs
@@ -1,10 +1,10 @@
 use http_req::request;
 
 fn main() {
-    //Container for body of a response.
+    // Container for body of a response.
     let mut body = Vec::new();
 
-    //Sends a HTTP GET request and processes the response. Saves body of the response to `body` variable.
+    // Sends a HTTP GET request and processes the response. Saves body of the response to `body` variable.
     let res = request::get("https://www.rust-lang.org/learn", &mut body).unwrap();
 
     //Prints details about the response.

--- a/examples/get.rs
+++ b/examples/get.rs
@@ -1,14 +1,28 @@
 use http_req::request;
+use http_req::{request::Request, response::StatusCode, uri::Uri};
+use std::convert::TryFrom;
+use std::fs::File;
 
 fn main() {
     //Container for body of a response.
-    let mut body = Vec::new();
+    //let mut body = Vec::new();
 
     //Sends a HTTP GET request and processes the response. Saves body of the response to `body` variable.
-    let res = request::get("https://www.rust-lang.org/learn", &mut body).unwrap();
+    //let res = request::get("https://drivers.amd.com/drivers/installer/23.40/whql/amd-software-adrenalin-edition-24.5.1-minimalsetup-240514_web.exe", &mut body).unwrap();
 
     //Prints details about the response.
-    println!("Status: {} {}", res.status_code(), res.reason());
-    println!("Headers: {}", res.headers());
+    //println!("Status: {} {}", res.status_code(), res.reason());
+    //println!("Headers: {}", res.headers());
     //println!("{}", String::from_utf8_lossy(&body));
+
+    let mut writer = File::create("boo.txt").unwrap();
+    let uri = Uri::try_from("https://drivers.amd.com/drivers/whql-amd-software-adrenalin-edition-24.5.1-win10-win11-may15-rdna.exe").unwrap();
+
+    let response = Request::new(&uri)
+        .header("Referer", &uri)
+        .send(&mut writer)
+        .unwrap();
+
+    println!("Status: {} {}", response.status_code(), response.reason());
+    println!("Headers: {}", response.headers());
 }

--- a/examples/head.rs
+++ b/examples/head.rs
@@ -1,10 +1,10 @@
 use http_req::request;
 
 fn main() {
-    //Sends a HTTP HEAD request and processes the response.
+    // Sends a HTTP HEAD request and processes the response.
     let res = request::head("https://www.rust-lang.org/learn").unwrap();
 
-    //Prints details about the response.
+    // Prints the details about the response.
     println!("Status: {} {}", res.status_code(), res.reason());
     println!("Headers: {}", res.headers());
 }

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -1,17 +1,17 @@
 use http_req::request;
 
 fn main() {
-    //Container for body of a response.
+    // Container for body of a response.
     let mut res_body = Vec::new();
 
-    //Body of a request.
+    // Body of a request.
     const REQ_BODY: &[u8; 27] = b"field1=value1&field2=value2";
 
-    //Sends a HTTP POST request and processes the response.
+    // Sends a HTTP POST request and processes the response.
     let res = request::post("https://httpbin.org/post", REQ_BODY, &mut res_body).unwrap();
 
-    //Prints details about the response.
+    // Prints details about the response.
     println!("Status: {} {}", res.status_code(), res.reason());
     println!("Headers: {}", res.headers());
-    println!("{}", String::from_utf8_lossy(&res_body));
+    //println!("{}", String::from_utf8_lossy(&res_body));
 }

--- a/examples/request_builder_get.rs
+++ b/examples/request_builder_get.rs
@@ -11,35 +11,35 @@ use std::{
 };
 
 fn main() {
-    //Parses a URI and assigns it to a variable `addr`.
+    // Parses a URI and assigns it to a variable `addr`.
     let addr: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
 
-    //Containers for a server's response.
+    // Containers for a server's response.
     let raw_head;
     let mut body = Vec::new();
 
-    //Prepares a request message.
+    // Prepares a request message.
     let request_msg = RequestBuilder::new(&addr)
         .header("Connection", "Close")
         .parse();
 
-    //Connects to a server. Uses information from `addr`.
+    // Connects to a server. Uses information from `addr`.
     let mut stream = Stream::new(&addr, Some(Duration::from_secs(60))).unwrap();
     stream = Stream::try_to_https(stream, &addr, None).unwrap();
 
-    //Makes a request to server - sends a prepared message.
+    // Makes a request to server. Sends the prepared message.
     stream.write_all(&request_msg).unwrap();
 
-    //Wraps the stream in BufReader to make it easier to read from it.
-    //Reads a response from the server and saves the head to `raw_head`, and the body to `body`.
+    // Wraps the stream in BufReader to make it easier to read from it.
+    // Reads a response from the server and saves the head to `raw_head`, and the body to `body`.
     let mut stream = BufReader::new(stream);
     raw_head = stream::read_head(&mut stream);
     stream.read_to_end(&mut body).unwrap();
 
-    //Parses and processes the response.
+    // Parses and processes the response.
     let response = Response::from_head(&raw_head).unwrap();
 
-    //Prints infromation about the response.
+    // Prints infromation about the response.
     println!("Status: {} {}", response.status_code(), response.reason());
     println!("Headers: {}", response.headers());
     //println!("{}", String::from_utf8_lossy(&body));

--- a/examples/request_builder_get.rs
+++ b/examples/request_builder_get.rs
@@ -1,12 +1,7 @@
-use http_req::{
-    request::RequestBuilder,
-    response::{find_slice, Response},
-    stream::Stream,
-    uri::Uri,
-};
+use http_req::{request::RequestBuilder, response::Response, stream::Stream, uri::Uri};
 use std::{
     convert::TryFrom,
-    io::{Read, Write},
+    io::{BufRead, BufReader, Read, Write},
     time::Duration,
 };
 
@@ -14,30 +9,45 @@ fn main() {
     //Parses a URI and assigns it to a variable `addr`.
     let addr: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
 
-    //Prepare a request
-    let mut request_builder = RequestBuilder::new(&addr);
-    request_builder.header("Connection", "Close");
+    //Containers for a server's response.
+    let mut raw_head = Vec::new();
+    let mut body = Vec::new();
 
-    //Container for a server's response.
-    let mut writer = Vec::new();
+    //Prepares a request message.
+    let request_msg = RequestBuilder::new(&addr)
+        .header("Connection", "Close")
+        .parse();
 
-    //Connects to a remote host. Uses information from `addr`.
+    println!("{:?}", String::from_utf8(request_msg.clone()));
+
+    //Connects to a server. Uses information from `addr`.
     let mut stream = Stream::new(&addr, Some(Duration::from_secs(60))).unwrap();
     stream = Stream::try_to_https(stream, &addr, None).unwrap();
 
-    //Generate a request (message) and send it to server.
-    let request_msg = request_builder.parse_msg();
+    //Makes a request to server - sends a prepared message.
     stream.write_all(&request_msg).unwrap();
 
-    //Read response from the server and save it to writer
-    stream.read_to_end(&mut writer).unwrap();
+    //Wraps the stream in BufReader to make it easier to read from it.
+    //Reads a response from the server and saves the head to `raw_head`, and the body to `body`.
+    let mut stream = BufReader::new(stream);
+    loop {
+        match stream.read_until(0xA, &mut raw_head) {
+            Ok(0) | Err(_) => break,
+            Ok(len) => {
+                let full_len = raw_head.len();
 
-    //Parse and process response.
-    let pos = find_slice(&writer, &[13, 10, 13, 10].to_owned()).unwrap();
-    let response = Response::from_head(&writer[..pos]).unwrap();
-    let body = writer[pos..].to_vec();
+                if len == 2 && &raw_head[full_len - 2..] == b"\r\n" {
+                    break;
+                }
+            }
+        }
+    }
+    stream.read_to_end(&mut body).unwrap();
 
-    //Print infromation about the response.
+    //Parses and processes the response.
+    let response = Response::from_head(&raw_head).unwrap();
+
+    //Prints infromation about the response.
     println!("Status: {} {}", response.status_code(), response.reason());
     println!("Headers: {}", response.headers());
     //println!("{}", String::from_utf8_lossy(&body));

--- a/examples/request_builder_get.rs
+++ b/examples/request_builder_get.rs
@@ -14,15 +14,15 @@ fn main() {
         .unwrap();
 
     //Container for a response's body.
-    let mut writer = Vec::new();
+    //let mut writer = Vec::new();
 
     //Adds a header `Connection: Close`.
     let response = RequestBuilder::new(&addr)
-        .header("Connection", "Close")
-        .send(&mut stream, &mut writer)
-        .unwrap();
+        .header("Connection", "Close");
+      //  .send(&mut stream, &mut writer)
+       // .unwrap();
 
-    println!("Status: {} {}", response.status_code(), response.reason());
-    println!("Headers: {}", response.headers());
+    //println!("Status: {} {}", response.status_code(), response.reason());
+    //println!("Headers: {}", response.headers());
     //println!("{}", String::from_utf8_lossy(&writer));
 }

--- a/src/chunked.rs
+++ b/src/chunked.rs
@@ -1,15 +1,16 @@
-//! module chunked implements the wire protocol for HTTP's "chunked" Transfer-Encoding.
-//! And it's a rust version of the reference implementation in [Go][1].
-//!
-//! [1]: https://golang.google.cn/src/net/http/internal/chunked.go
-//!
+//!implements the wire protocol for HTTP's "chunked" Transfer-Encoding.
+/// 
+///It's a Rust version of the reference implementation in [Go][1].
+///
+///[1]: https://golang.google.cn/src/net/http/internal/chunked.go
+///
 
 use std::io::{self, BufRead, BufReader, Error, ErrorKind, Read};
 
 const MAX_LINE_LENGTH: usize = 4096;
 const CR_LF: [u8; 2] = [b'\r', b'\n'];
 
-pub struct Reader<R> {
+pub struct ChunkReader<R> {
     check_end: bool,
     eof: bool,
     err: Option<Error>,
@@ -17,7 +18,7 @@ pub struct Reader<R> {
     reader: BufReader<R>,
 }
 
-impl<R> Read for Reader<R>
+impl<R> Read for ChunkReader<R>
 where
     R: Read,
 {
@@ -93,7 +94,29 @@ where
     }
 }
 
-impl<R> Reader<R>
+impl<R: Read> BufRead for ChunkReader<R> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        self.reader.fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.reader.consume(amt)
+    }
+}
+
+impl<R: Read> From<BufReader<R>> for ChunkReader<R> {
+    fn from(value: BufReader<R>) -> Self {
+        ChunkReader {
+            check_end: false,
+            eof: false,
+            err: None,
+            n: 0,
+            reader: value,
+        }
+    }
+}
+
+impl<R> ChunkReader<R>
 where
     R: Read,
 {
@@ -216,7 +239,7 @@ mod tests {
     #[test]
     fn read() {
         let data: &[u8] = b"7\r\nhello, \r\n17\r\nworld! 0123456789abcdef\r\n0\r\n";
-        let mut reader = Reader::new(data);
+        let mut reader = ChunkReader::new(data);
         let mut writer = vec![];
         io::copy(&mut reader, &mut writer).expect("failed to dechunk");
 
@@ -226,7 +249,7 @@ mod tests {
     fn read_multiple() {
         {
             let data: &[u8] = b"3\r\nfoo\r\n3\r\nbar\r\n0\r\n";
-            let mut reader = Reader::new(data);
+            let mut reader = ChunkReader::new(data);
             let mut writer = vec![0u8; 10];
             let n = reader.read(&mut writer).expect("unexpect error");
 
@@ -235,7 +258,7 @@ mod tests {
         }
         {
             let data: &[u8] = b"3\r\nfoo\r\n0\r\n";
-            let mut reader = Reader::new(data);
+            let mut reader = ChunkReader::new(data);
             let mut writer = vec![0u8; 3];
             let n = reader.read(&mut writer).expect("unexpect error");
 
@@ -246,7 +269,7 @@ mod tests {
     #[test]
     fn read_partial() {
         let data: &[u8] = b"7\r\n1234567";
-        let mut reader = Reader::new(data);
+        let mut reader = ChunkReader::new(data);
         let mut writer = vec![];
         io::copy(&mut reader, &mut writer).expect("failed to dechunk");
 
@@ -260,7 +283,7 @@ mod tests {
             + "world! 0123456789abcdef\r\n"
             + "0;someextension=sometoken\r\n";
         let data = data_str.as_bytes();
-        let mut reader = Reader::new(data);
+        let mut reader = ChunkReader::new(data);
         let mut writer = vec![];
 
         reader.read_to_end(&mut writer).expect("failed to dechunk");

--- a/src/chunked.rs
+++ b/src/chunked.rs
@@ -1,14 +1,13 @@
-//! implements the wire protocol for HTTP's "chunked" Transfer-Encoding.
+//! support for Transfer-Encoding: chunked
 use crate::CR_LF;
-///
-/// It's a Rust version of the reference implementation in [Go][1].
-///
-/// [1]: https://golang.google.cn/src/net/http/internal/chunked.go
-///
 use std::io::{self, BufRead, BufReader, Error, ErrorKind, Read};
 
 const MAX_LINE_LENGTH: usize = 4096;
 
+/// Implements the wire protocol for HTTP's Transfer-Encoding: chunked.
+///
+/// It's a Rust version of the [reference implementation in Go](https://golang.google.cn/src/net/http/internal/chunked.go)
+///
 pub struct ChunkReader<R> {
     check_end: bool,
     eof: bool,
@@ -103,7 +102,10 @@ impl<R: Read> BufRead for ChunkReader<R> {
     }
 }
 
-impl<R: Read> From<BufReader<R>> for ChunkReader<R> {
+impl<R> From<BufReader<R>> for ChunkReader<R>
+where
+    R: Read,
+{
     fn from(value: BufReader<R>) -> Self {
         ChunkReader {
             check_end: false,
@@ -119,6 +121,7 @@ impl<R> ChunkReader<R>
 where
     R: Read,
 {
+    /// Creates a new `ChunkReader` from `reader`
     pub fn new(reader: R) -> Self
     where
         R: Read,

--- a/src/chunked.rs
+++ b/src/chunked.rs
@@ -7,7 +7,6 @@ const MAX_LINE_LENGTH: usize = 4096;
 /// Implements the wire protocol for HTTP's Transfer-Encoding: chunked.
 ///
 /// It's a Rust version of the [reference implementation in Go](https://golang.google.cn/src/net/http/internal/chunked.go)
-///
 pub struct ChunkReader<R> {
     check_end: bool,
     eof: bool,
@@ -92,7 +91,10 @@ where
     }
 }
 
-impl<R: Read> BufRead for ChunkReader<R> {
+impl<R> BufRead for ChunkReader<R>
+where
+    R: Read,
+{
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         self.reader.fill_buf()
     }

--- a/src/chunked.rs
+++ b/src/chunked.rs
@@ -1,14 +1,13 @@
-//!implements the wire protocol for HTTP's "chunked" Transfer-Encoding.
-/// 
-///It's a Rust version of the reference implementation in [Go][1].
+//! implements the wire protocol for HTTP's "chunked" Transfer-Encoding.
+use crate::CR_LF;
 ///
-///[1]: https://golang.google.cn/src/net/http/internal/chunked.go
+/// It's a Rust version of the reference implementation in [Go][1].
 ///
-
+/// [1]: https://golang.google.cn/src/net/http/internal/chunked.go
+///
 use std::io::{self, BufRead, BufReader, Error, ErrorKind, Read};
 
 const MAX_LINE_LENGTH: usize = 4096;
-const CR_LF: [u8; 2] = [b'\r', b'\n'];
 
 pub struct ChunkReader<R> {
     check_end: bool,
@@ -37,7 +36,7 @@ where
                 }
 
                 if let Ok(_) = self.reader.read_exact(&mut footer) {
-                    if footer != CR_LF {
+                    if &footer != CR_LF {
                         self.err = Some(error_malformed_chunked_encoding());
                         break;
                     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//!error system
+//! error system used around the library.
 use std::{error, fmt, io, num, str, sync::mpsc};
 
 #[derive(Debug, PartialEq)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,8 +10,6 @@ pub enum ParseErr {
     UriErr,
     Invalid,
     Empty,
-    #[cfg(feature = "rust-tls")]
-    Rustls(rustls::Error),
 }
 
 impl error::Error for ParseErr {
@@ -22,8 +20,6 @@ impl error::Error for ParseErr {
             Utf8(e) => Some(e),
             Int(e) => Some(e),
             StatusErr | HeadersErr | UriErr | Invalid | Empty => None,
-            #[cfg(feature = "rust-tls")]
-            Rustls(e) => Some(e),
         }
     }
 }
@@ -40,17 +36,8 @@ impl fmt::Display for ParseErr {
             StatusErr => "status line contains invalid values",
             HeadersErr => "headers contain invalid values",
             UriErr => "uri contains invalid characters",
-            #[cfg(feature = "rust-tls")]
-            Rustls(_) => "rustls error",
         };
         write!(f, "ParseErr: {}", err)
-    }
-}
-
-#[cfg(feature = "rust-tls")]
-impl From<rustls::Error> for ParseErr {
-    fn from(e: rustls::Error) -> Self {
-        ParseErr::Rustls(e)
     }
 }
 
@@ -93,9 +80,9 @@ impl fmt::Display for Error {
 
         let err = match self {
             IO(_) => "IO error",
-            Tls => "TLS error",
-            Timeout(_) => "Timeout error",
             Parse(err) => return err.fmt(f),
+            Timeout(_) => "Timeout error",
+            Tls => "TLS error",
         };
         write!(f, "Error: {}", err)
     }
@@ -136,5 +123,12 @@ impl From<str::Utf8Error> for Error {
 impl From<mpsc::RecvTimeoutError> for Error {
     fn from(e: mpsc::RecvTimeoutError) -> Self {
         Error::Timeout(e)
+    }
+}
+
+#[cfg(feature = "rust-tls")]
+impl From<rustls::Error> for Error {
+    fn from(_e: rustls::Error) -> Self {
+        Error::Tls
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,10 @@
 //!    println!("Status: {} {}", res.status_code(), res.reason());
 //!}
 //!```
-pub mod error;
+pub mod uri;
 pub mod request;
 pub mod response;
 pub mod stream;
+pub mod chunked;
 pub mod tls;
-pub mod uri;
-
-mod chunked;
+pub mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod error;
 pub mod request;
 pub mod response;
+pub mod stream;
 pub mod tls;
 pub mod uri;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,26 @@
-//!Simple HTTP client with built-in HTTPS support.
-//!Currently it's in heavy development and may frequently change.
+//! Simple HTTP client with built-in HTTPS support.
+//! Currently it's in heavy development and may frequently change.
 //!
-//!## Example
-//!Basic GET request
-//!```
-//!use http_req::request;
+//! ## Example
+//! Basic GET request
+//! ```
+//! use http_req::request;
 //!
-//!fn main() {
-//!    //Container for body of a response   
-//!    let mut body = Vec::new();
-//!    let res = request::get("https://doc.rust-lang.org/", &mut body).unwrap();
+//! fn main() {
+//!     //Container for body of a response   
+//!     let mut body = Vec::new();
+//!     let res = request::get("https://doc.rust-lang.org/", &mut body).unwrap();
 //!
-//!    println!("Status: {} {}", res.status_code(), res.reason());
-//!}
-//!```
-pub mod uri;
+//!     println!("Status: {} {}", res.status_code(), res.reason());
+//! }
+//! ```
+pub mod chunked;
+pub mod error;
 pub mod request;
 pub mod response;
 pub mod stream;
-pub mod chunked;
 pub mod tls;
-pub mod error;
+pub mod uri;
+
+pub(crate) const CR_LF: &[u8; 2] = b"\r\n";
+pub(crate) const LF: u8 = 0xA;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //! Simple HTTP client with built-in HTTPS support.
-//! Currently it's in heavy development and may frequently change.
+//! 
+//! By default uses [rust-native-tls](https://github.com/sfackler/rust-native-tls),
+//! which relies on TLS framework provided by OS on Windows and macOS, and OpenSSL
+//! on all other platforms. But it also supports [rus-tls](https://crates.io/crates/rustls).
 //!
 //! ## Example
 //! Basic GET request

--- a/src/request.rs
+++ b/src/request.rs
@@ -18,7 +18,7 @@ use std::{
 const CR_LF: &str = "\r\n";
 const DEFAULT_REQ_TIMEOUT: u64 = 12 * 60 * 60;
 
-///HTTP request methods
+/// HTTP request methods
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Method {
     GET,
@@ -48,7 +48,7 @@ impl fmt::Display for Method {
     }
 }
 
-///HTTP versions
+/// HTTP versions
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum HttpVersion {
     Http10,
@@ -74,19 +74,19 @@ impl fmt::Display for HttpVersion {
     }
 }
 
-///Raw HTTP request that can be sent to any stream
+/// Raw HTTP request that can be sent to any stream
 ///
-///# Examples
-///```
-///use std::convert::TryFrom;
-///use http_req::{request::RequestBuilder, uri::Uri};
+/// # Examples
+/// ```
+/// use std::convert::TryFrom;
+/// use http_req::{request::RequestBuilder, uri::Uri};
 ///
-///let addr: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+/// let addr: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
 ///
-///let mut request_msg = RequestBuilder::new(&addr)
-///     .header("Connection", "Close")
-///     .parse();
-///```
+/// let mut request_msg = RequestBuilder::new(&addr)
+///      .header("Connection", "Close")
+///      .parse();
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct RequestBuilder<'a> {
     uri: &'a Uri<'a>,
@@ -97,18 +97,18 @@ pub struct RequestBuilder<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
-    ///Creates new `RequestBuilder` with default parameters
+    /// Creates a new `RequestBuilder` with default parameters
     ///
-    ///# Examples
-    ///```
-    ///use std::convert::TryFrom;
-    ///use http_req::{request::RequestBuilder, uri::Uri};
+    /// # Examples
+    /// ```
+    /// use std::convert::TryFrom;
+    /// use http_req::{request::RequestBuilder, uri::Uri};
     ///
-    ///let addr = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let addr = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    ///let request_builder = RequestBuilder::new(&addr)
-    ///    .header("Connection", "Close");
-    ///```
+    /// let request_builder = RequestBuilder::new(&addr)
+    ///     .header("Connection", "Close");
+    /// ```
     pub fn new(uri: &'a Uri<'a>) -> RequestBuilder<'a> {
         RequestBuilder {
             headers: Headers::default_http(uri),
@@ -119,18 +119,18 @@ impl<'a> RequestBuilder<'a> {
         }
     }
 
-    ///Sets request method
+    /// Sets the request method
     ///
-    ///# Examples
-    ///```
-    ///use std::convert::TryFrom;
-    ///use http_req::{request::{RequestBuilder, Method}, uri::Uri};
+    /// # Examples
+    /// ```
+    /// use std::convert::TryFrom;
+    /// use http_req::{request::{RequestBuilder, Method}, uri::Uri};
     ///
-    ///let addr = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let addr = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    ///let request_builder = RequestBuilder::new(&addr)
-    ///    .method(Method::HEAD);
-    ///```
+    /// let request_builder = RequestBuilder::new(&addr)
+    ///     .method(Method::HEAD);
+    /// ```
     pub fn method<T>(&mut self, method: T) -> &mut Self
     where
         Method: From<T>,
@@ -139,18 +139,18 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
-    ///Sets HTTP version
+    /// Sets the HTTP version
     ///
-    ///# Examples
-    ///```
-    ///use std::convert::TryFrom;
-    ///use http_req::{request::{RequestBuilder, HttpVersion}, uri::Uri};
+    /// # Examples
+    /// ```
+    /// use std::convert::TryFrom;
+    /// use http_req::{request::{RequestBuilder, HttpVersion}, uri::Uri};
     ///
-    ///let addr = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let addr = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    ///let request_builder = RequestBuilder::new(&addr)
-    ///    .version(HttpVersion::Http10);
-    ///```
+    /// let request_builder = RequestBuilder::new(&addr)
+    ///     .version(HttpVersion::Http10);
+    /// ```
     pub fn version<T>(&mut self, version: T) -> &mut Self
     where
         HttpVersion: From<T>,
@@ -159,24 +159,24 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
-    ///Replaces all it's headers with headers passed to the function
+    /// Replaces all it's headers with headers passed to the function
     ///
-    ///# Examples
-    ///```
-    ///use std::convert::TryFrom;
-    ///use http_req::{request::RequestBuilder, response::Headers, uri::Uri};
+    /// # Examples
+    /// ```
+    /// use std::convert::TryFrom;
+    /// use http_req::{request::RequestBuilder, response::Headers, uri::Uri};
     ///
-    ///let addr = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let addr = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    ///let mut headers = Headers::new();
-    ///headers.insert("Accept-Charset", "utf-8");
-    ///headers.insert("Accept-Language", "en-US");
-    ///headers.insert("Host", "rust-lang.org");
-    ///headers.insert("Connection", "Close");
+    /// let mut headers = Headers::new();
+    /// headers.insert("Accept-Charset", "utf-8");
+    /// headers.insert("Accept-Language", "en-US");
+    /// headers.insert("Host", "rust-lang.org");
+    /// headers.insert("Connection", "Close");
     ///
-    ///let request_builder = RequestBuilder::new(&addr)
-    ///    .headers(headers);
-    ///```
+    /// let request_builder = RequestBuilder::new(&addr)
+    ///     .headers(headers);
+    /// ```
     pub fn headers<T>(&mut self, headers: T) -> &mut Self
     where
         Headers: From<T>,
@@ -185,18 +185,18 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
-    ///Adds new header to existing/default headers
+    /// Adds a new header to existing/default headers
     ///
-    ///# Examples
-    ///```
-    ///use std::convert::TryFrom;
-    ///use http_req::{request::RequestBuilder, response::Headers, uri::Uri};
+    /// # Examples
+    /// ```
+    /// use std::convert::TryFrom;
+    /// use http_req::{request::RequestBuilder, response::Headers, uri::Uri};
     ///
-    ///let addr = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let addr = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    ///let request_builder = RequestBuilder::new(&addr)
-    ///    .header("Connection", "Close");
-    ///```
+    /// let request_builder = RequestBuilder::new(&addr)
+    ///     .header("Connection", "Close");
+    /// ```
     pub fn header<T, U>(&mut self, key: &T, val: &U) -> &mut Self
     where
         T: ToString + ?Sized,
@@ -206,43 +206,40 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
-    ///Sets body for request
+    /// Sets the body for request
     ///
-    ///# Examples
-    ///```
-    ///use std::convert::TryFrom;
-    ///use http_req::{request::{RequestBuilder, Method}, response::Headers, uri::Uri};
+    /// # Examples
+    /// ```
+    /// use std::convert::TryFrom;
+    /// use http_req::{request::{RequestBuilder, Method}, response::Headers, uri::Uri};
     ///
-    ///let addr = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
-    ///const BODY: &[u8; 27] = b"field1=value1&field2=value2";
+    /// let addr = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// const BODY: &[u8; 27] = b"field1=value1&field2=value2";
     ///
-    ///let request_builder = RequestBuilder::new(&addr)
-    ///    .method(Method::POST)
-    ///    .body(BODY)
-    ///    .header("Content-Length", &BODY.len())
-    ///    .header("Connection", "Close");
-    ///```
+    /// let request_builder = RequestBuilder::new(&addr)
+    ///     .method(Method::POST)
+    ///     .body(BODY)
+    ///     .header("Content-Length", &BODY.len())
+    ///     .header("Connection", "Close");
+    /// ```
     pub fn body(&mut self, body: &'a [u8]) -> &mut Self {
         self.body = Some(body);
         self
     }
 
-    ///Parses request message for this `RequestBuilder`
+    /// Parses the request message for this `RequestBuilder`
     ///
-    ///# Examples
-    ///```
-    ///use std::convert::TryFrom;
-    ///use http_req::{request::RequestBuilder, uri::Uri};
+    /// # Examples
+    /// ```
+    /// use std::convert::TryFrom;
+    /// use http_req::{request::RequestBuilder, uri::Uri};
     ///
-    ///let addr: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let addr: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    ///let mut request_msg = RequestBuilder::new(&addr)
-    ///     .header("Connection", "Close")
-    ///     .parse();
-    ///
-    ///let expected_msg = "GET /learn HTTP/1.1\r\nHost: www.rust-lang.org\r\nConnection: Close\r\n\r\n";
-    ///assert_eq!(String::from_utf8(request_msg).unwrap(), expected_msg);
-    ///```
+    /// let mut request_msg = RequestBuilder::new(&addr)
+    ///      .header("Connection", "Close")
+    ///      .parse();
+    /// ```
     pub fn parse(&self) -> Vec<u8> {
         let request_line = format!(
             "{} {} {}{}",
@@ -268,22 +265,22 @@ impl<'a> RequestBuilder<'a> {
     }
 }
 
-///Allows for making HTTP requests based on specified parameters.
+/// Allows for making HTTP requests based on specified parameters.
 ///
-///It creates stream (`TcpStream` or `TlsStream`) appropriate for the type of uri (`http`/`https`).
-///By default it closes connection after completion of the response.
+/// It creates a stream (`TcpStream` or `TlsStream`) appropriate for the type of uri (`http`/`https`).
+/// By default it closes connection after completion of the response.
 ///
-///# Examples
-///```
-///use http_req::{request::Request, uri::Uri, response::StatusCode};
-///use std::convert::TryFrom;
+/// # Examples
+/// ```
+/// use http_req::{request::Request, uri::Uri, response::StatusCode};
+/// use std::convert::TryFrom;
 ///
-///let mut writer = Vec::new();
-///let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+/// let mut writer = Vec::new();
+/// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
 ///
-///let response = Request::new(&uri).send(&mut writer).unwrap();;
-///assert_eq!(response.status_code(), StatusCode::new(200));
-///```
+/// let response = Request::new(&uri).send(&mut writer).unwrap();;
+/// assert_eq!(response.status_code(), StatusCode::new(200));
+/// ```
 ///
 #[derive(Clone, Debug, PartialEq)]
 pub struct Request<'a> {
@@ -296,18 +293,18 @@ pub struct Request<'a> {
 }
 
 impl<'a> Request<'a> {
-    ///Creates new `Request` with default parameters.
+    /// Creates a new `Request` with default parameters.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{request::Request, uri::Uri};
-    ///use std::convert::TryFrom;
+    /// # Examples
+    /// ```
+    /// use http_req::{request::Request, uri::Uri};
+    /// use std::convert::TryFrom;
     ///
-    ///let mut writer = Vec::new();
-    ///let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let mut writer = Vec::new();
+    /// let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    ///let response = Request::new(&uri).send(&mut writer).unwrap();;
-    ///```
+    /// let response = Request::new(&uri).send(&mut writer).unwrap();;
+    /// ```
     pub fn new(uri: &'a Uri) -> Request<'a> {
         let mut builder = RequestBuilder::new(&uri);
         builder.header("Connection", "Close");
@@ -322,18 +319,18 @@ impl<'a> Request<'a> {
         }
     }
 
-    ///Sets request method.
+    /// Sets the request method.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{request::{Request, Method}, uri::Uri};
-    ///use std::convert::TryFrom;
+    /// # Examples
+    /// ```
+    /// use http_req::{request::{Request, Method}, uri::Uri};
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    ///let response = Request::new(&uri)
-    ///    .method(Method::HEAD);
-    ///```
+    /// let response = Request::new(&uri)
+    ///     .method(Method::HEAD);
+    /// ```
     pub fn method<T>(&mut self, method: T) -> &mut Self
     where
         Method: From<T>,
@@ -342,18 +339,18 @@ impl<'a> Request<'a> {
         self
     }
 
-    ///Sets HTTP version.
+    /// Sets the HTTP version.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{request::{Request, HttpVersion}, uri::Uri};
-    ///use std::convert::TryFrom;
+    /// # Examples
+    /// ```
+    /// use http_req::{request::{Request, HttpVersion}, uri::Uri};
+    /// use std::convert::TryFrom;
     ///
-    ///let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    ///let response = Request::new(&uri)
-    ///    .version(HttpVersion::Http10);
-    ///```
+    /// let response = Request::new(&uri)
+    ///     .version(HttpVersion::Http10);
+    /// ```
 
     pub fn version<T>(&mut self, version: T) -> &mut Self
     where
@@ -363,24 +360,24 @@ impl<'a> Request<'a> {
         self
     }
 
-    ///Replaces all it's headers with headers passed to the function.
+    /// Replaces all it's headers with headers passed to the function.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{request::Request, uri::Uri, response::Headers};
-    ///use std::convert::TryFrom;
+    /// # Examples
+    /// ```
+    /// use http_req::{request::Request, uri::Uri, response::Headers};
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    ///let mut headers = Headers::new();
-    ///headers.insert("Accept-Charset", "utf-8");
-    ///headers.insert("Accept-Language", "en-US");
-    ///headers.insert("Host", "rust-lang.org");
-    ///headers.insert("Connection", "Close");
+    /// let mut headers = Headers::new();
+    /// headers.insert("Accept-Charset", "utf-8");
+    /// headers.insert("Accept-Language", "en-US");
+    /// headers.insert("Host", "rust-lang.org");
+    /// headers.insert("Connection", "Close");
     ///
-    ///let response = Request::new(&uri)
-    ///    .headers(headers);
-    ///```
+    /// let response = Request::new(&uri)
+    ///     .headers(headers);
+    /// ```
     pub fn headers<T>(&mut self, headers: T) -> &mut Self
     where
         Headers: From<T>,
@@ -389,18 +386,18 @@ impl<'a> Request<'a> {
         self
     }
 
-    ///Adds header to existing/default headers.
+    /// Adds the header to existing/default headers.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{request::Request, uri::Uri};
-    ///use std::convert::TryFrom;
+    /// # Examples
+    /// ```
+    /// use http_req::{request::Request, uri::Uri};
+    /// use std::convert::TryFrom;
     ///
-    ///let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    ///let response = Request::new(&uri)
-    ///    .header("Accept-Language", "en-US");
-    ///```
+    /// let response = Request::new(&uri)
+    ///     .header("Accept-Language", "en-US");
+    /// ```
     pub fn header<T, U>(&mut self, key: &T, val: &U) -> &mut Self
     where
         T: ToString + ?Sized,
@@ -410,48 +407,48 @@ impl<'a> Request<'a> {
         self
     }
 
-    ///Sets body for request.
+    /// Sets the body for request.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{request::{Request, Method}, uri::Uri};
-    ///use std::convert::TryFrom;
+    /// # Examples
+    /// ```
+    /// use http_req::{request::{Request, Method}, uri::Uri};
+    /// use std::convert::TryFrom;
     ///
-    ///let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
-    ///const body: &[u8; 27] = b"field1=value1&field2=value2";
+    /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// const body: &[u8; 27] = b"field1=value1&field2=value2";
     ///
-    ///let response = Request::new(&uri)
-    ///    .method(Method::POST)
-    ///    .header("Content-Length", &body.len())
-    ///    .body(body);
-    ///```
+    /// let response = Request::new(&uri)
+    ///     .method(Method::POST)
+    ///     .header("Content-Length", &body.len())
+    ///     .body(body);
+    /// ```
     pub fn body(&mut self, body: &'a [u8]) -> &mut Self {
         self.inner.body(body);
         self
     }
 
-    ///Sets connect timeout while using internal `TcpStream` instance.
+    /// Sets the connect timeout while using internal `TcpStream` instance.
     ///
-    ///- If there is a timeout, it will be passed to
-    ///  [`TcpStream::connect_timeout`][TcpStream::connect_timeout].
-    ///- If `None` is provided, [`TcpStream::connect`][TcpStream::connect] will
-    ///  be used. A timeout will still be enforced by the operating system, but
-    ///  the exact value depends on the platform.
+    /// - If there is a timeout, it will be passed to
+    ///   [`TcpStream::connect_timeout`][TcpStream::connect_timeout].
+    /// - If `None` is provided, [`TcpStream::connect`][TcpStream::connect] will
+    ///   be used. A timeout will still be enforced by the operating system, but
+    ///   the exact value depends on the platform.
     ///
-    ///[TcpStream::connect]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.connect
-    ///[TcpStream::connect_timeout]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.connect_timeout
+    /// [TcpStream::connect]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.connect
+    /// [TcpStream::connect_timeout]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.connect_timeout
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{request::Request, uri::Uri};
-    ///use std::{time::Duration, convert::TryFrom};
+    /// # Examples
+    /// ```
+    /// use http_req::{request::Request, uri::Uri};
+    /// use std::{time::Duration, convert::TryFrom};
     ///
-    ///let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
-    ///const time: Option<Duration> = Some(Duration::from_secs(10));
+    /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// const time: Option<Duration> = Some(Duration::from_secs(10));
     ///
-    ///let response = Request::new(&uri)
-    ///    .connect_timeout(time);
-    ///```
+    /// let response = Request::new(&uri)
+    ///     .connect_timeout(time);
+    /// ```
     pub fn connect_timeout<T>(&mut self, timeout: Option<T>) -> &mut Self
     where
         Duration: From<T>,
@@ -460,24 +457,24 @@ impl<'a> Request<'a> {
         self
     }
 
-    ///Sets read timeout on internal `TcpStream` instance.
+    /// Sets the read timeout on internal `TcpStream` instance.
     ///
-    ///`timeout` will be passed to
-    ///[`TcpStream::set_read_timeout`][TcpStream::set_read_timeout].
+    /// `timeout` will be passed to
+    /// [`TcpStream::set_read_timeout`][TcpStream::set_read_timeout].
     ///
-    ///[TcpStream::set_read_timeout]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_read_timeout
+    /// [TcpStream::set_read_timeout]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_read_timeout
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{request::Request, uri::Uri};
-    ///use std::{time::Duration, convert::TryFrom};
+    /// # Examples
+    /// ```
+    /// use http_req::{request::Request, uri::Uri};
+    /// use std::{time::Duration, convert::TryFrom};
     ///
-    ///let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
-    ///const time: Option<Duration> = Some(Duration::from_secs(15));
+    /// let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// const time: Option<Duration> = Some(Duration::from_secs(15));
     ///
-    ///let response = Request::new(&uri)
-    ///    .read_timeout(time);
-    ///```
+    /// let response = Request::new(&uri)
+    ///     .read_timeout(time);
+    /// ```
     pub fn read_timeout<T>(&mut self, timeout: Option<T>) -> &mut Self
     where
         Duration: From<T>,
@@ -486,24 +483,24 @@ impl<'a> Request<'a> {
         self
     }
 
-    ///Sets write timeout on internal `TcpStream` instance.
+    /// Sets the write timeout on internal `TcpStream` instance.
     ///
-    ///`timeout` will be passed to
-    ///[`TcpStream::set_write_timeout`][TcpStream::set_write_timeout].
+    /// `timeout` will be passed to
+    /// [`TcpStream::set_write_timeout`][TcpStream::set_write_timeout].
     ///
-    ///[TcpStream::set_write_timeout]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_write_timeout
+    /// [TcpStream::set_write_timeout]: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_write_timeout
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{request::Request, uri::Uri};
-    ///use std::{time::Duration, convert::TryFrom};
+    /// # Examples
+    /// ```
+    /// use http_req::{request::Request, uri::Uri};
+    /// use std::{time::Duration, convert::TryFrom};
     ///
-    ///let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
-    ///const time: Option<Duration> = Some(Duration::from_secs(5));
+    /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// const time: Option<Duration> = Some(Duration::from_secs(5));
     ///
-    ///let response = Request::new(&uri)
-    ///    .write_timeout(time);
-    ///```
+    /// let response = Request::new(&uri)
+    ///     .write_timeout(time);
+    /// ```
     pub fn write_timeout<T>(&mut self, timeout: Option<T>) -> &mut Self
     where
         Duration: From<T>,
@@ -512,20 +509,20 @@ impl<'a> Request<'a> {
         self
     }
 
-    ///Sets timeout on entire request. 
-    ///Data is read from a stream until the timeout is reached or there is no more data to read.
+    /// Sets the timeout on entire request.
+    /// Data is read from a stream until there is no more data to read or the timeout is exceeded.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{request::Request, uri::Uri};
-    ///use std::{time::Duration, convert::TryFrom};
+    /// # Examples
+    /// ```
+    /// use http_req::{request::Request, uri::Uri};
+    /// use std::{time::Duration, convert::TryFrom};
     ///
-    ///let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
-    ///const time: Duration = Duration::from_secs(5);
+    /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// const time: Duration = Duration::from_secs(5);
     ///
-    ///let response = Request::new(&uri)
-    ///    .timeout(time);
-    ///```
+    /// let response = Request::new(&uri)
+    ///     .timeout(time);
+    /// ```
     pub fn timeout<T>(&mut self, timeout: T) -> &mut Self
     where
         Duration: From<T>,
@@ -534,50 +531,50 @@ impl<'a> Request<'a> {
         self
     }
 
-    ///Add a file containing the PEM-encoded certificates that should be added in the trusted root store.
+    /// Adds the file containing the PEM-encoded certificates that should be added in the trusted root store.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{request::Request, uri::Uri};
-    ///use std::{time::Duration, convert::TryFrom, path::Path};
+    /// # Examples
+    /// ```
+    /// use http_req::{request::Request, uri::Uri};
+    /// use std::{time::Duration, convert::TryFrom, path::Path};
     ///
-    ///let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
-    ///let path = Path::new("./foo/bar.txt");
+    /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let path = Path::new("./foo/bar.txt");
     ///
-    ///let response = Request::new(&uri)
-    ///    .root_cert_file_pem(&path);
-    ///```
+    /// let response = Request::new(&uri)
+    ///     .root_cert_file_pem(&path);
+    /// ```
     pub fn root_cert_file_pem(&mut self, file_path: &'a Path) -> &mut Self {
         self.root_cert_file_pem = Some(file_path);
         self
     }
 
-    ///Sends HTTP request and returns `Response`.
+    /// Sends the HTTP request and returns `Response`.
     ///
-    ///Creates `TcpStream` (and wraps it with `TlsStream` if needed). Writes request message
-    ///to created stream. Returns response for this request. Writes response's body to `writer`.
+    /// Creates `TcpStream` (and wraps it with `TlsStream` if needed). Writes request message
+    /// to created stream. Returns response for this request. Writes response's body to `writer`.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{request::Request, uri::Uri};
-    ///use std::convert::TryFrom;
+    /// # Examples
+    /// ```
+    /// use http_req::{request::Request, uri::Uri};
+    /// use std::convert::TryFrom;
     ///
-    ///let mut writer = Vec::new();
-    ///let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let mut writer = Vec::new();
+    /// let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    ///let response = Request::new(&uri).send(&mut writer).unwrap();
-    ///```
+    /// let response = Request::new(&uri).send(&mut writer).unwrap();
+    /// ```
     pub fn send<T>(&self, writer: &mut T) -> Result<Response, error::Error>
     where
         T: Write,
     {
-        //Set up stream.
+        //Set up a stream.
         let mut stream = Stream::new(self.inner.uri, self.connect_timeout)?;
         stream.set_read_timeout(self.read_timeout)?;
         stream.set_write_timeout(self.write_timeout)?;
         stream = Stream::try_to_https(stream, self.inner.uri, self.root_cert_file_pem)?;
 
-        //Send request message to stream.
+        //Send the request message to stream.
         let request_msg = self.inner.parse();
         stream.write_all(&request_msg)?;
 
@@ -588,23 +585,23 @@ impl<'a> Request<'a> {
         let mut raw_response_head: Vec<u8> = Vec::new();
         let mut buf_reader = BufReader::new(stream);
 
-        //Read from stream and send over data via `sender`.
+        //Read from the stream and send over data via `sender`.
         thread::spawn(move || {
-            buf_reader.read_head(&sender);
+            buf_reader.send_head(&sender);
 
             let params: Vec<&str> = receiver_supp.recv().unwrap();
             if params.contains(&"non-empty") {
                 if params.contains(&"chunked") {
                     let mut buf_reader = ChunkReader::from(buf_reader);
-                    buf_reader.read_body(&sender);
+                    buf_reader.send_all(&sender);
                 } else {
-                    buf_reader.read_body(&sender);
+                    buf_reader.send_all(&sender);
                 }
             }
         });
 
         //Receive and process `head` of the response.
-        raw_response_head.write_head(&receiver, deadline);
+        raw_response_head.receive(&receiver, deadline);
 
         let response = Response::from_head(&raw_response_head)?;
         let content_len = response.content_len().unwrap_or(1);
@@ -625,24 +622,24 @@ impl<'a> Request<'a> {
 
         //Receive and process `body`` of the response.
         if content_len > 0 {
-            writer.write_body(&receiver, deadline);
+            writer.receive_all(&receiver, deadline);
         }
 
         Ok(response)
     }
 }
 
-///Creates and sends GET request. Returns response for this request.
+/// Creates and sends GET request. Returns response for this request.
 ///
-///# Examples
-///```
-///use http_req::request;
+/// # Examples
+/// ```
+/// use http_req::request;
 ///
-///let mut writer = Vec::new();
-///const uri: &str = "https://www.rust-lang.org/learn";
+/// let mut writer = Vec::new();
+/// const uri: &str = "https://www.rust-lang.org/learn";
 ///
-///let response = request::get(uri, &mut writer).unwrap();
-///```
+/// let response = request::get(uri, &mut writer).unwrap();
+/// ```
 pub fn get<T, U>(uri: T, writer: &mut U) -> Result<Response, error::Error>
 where
     T: AsRef<str>,
@@ -652,15 +649,15 @@ where
     Request::new(&uri).send(writer)
 }
 
-///Creates and sends HEAD request. Returns response for this request.
+/// Creates and sends HEAD request. Returns response for this request.
 ///
-///# Examples
-///```
-///use http_req::request;
+/// # Examples
+/// ```
+/// use http_req::request;
 ///
-///const uri: &str = "https://www.rust-lang.org/learn";
-///let response = request::head(uri).unwrap();
-///```
+/// const uri: &str = "https://www.rust-lang.org/learn";
+/// let response = request::head(uri).unwrap();
+/// ```
 pub fn head<T>(uri: T) -> Result<Response, error::Error>
 where
     T: AsRef<str>,
@@ -671,18 +668,18 @@ where
     Request::new(&uri).method(Method::HEAD).send(&mut writer)
 }
 
-///Creates and sends POST request. Returns response for this request.
+/// Creates and sends POST request. Returns response for this request.
 ///
-///# Examples
-///```
-///use http_req::request;
+/// # Examples
+/// ```
+/// use http_req::request;
 ///
-///let mut writer = Vec::new();
-///const uri: &str = "https://www.rust-lang.org/learn";
-///const body: &[u8; 27] = b"field1=value1&field2=value2";
+/// let mut writer = Vec::new();
+/// const uri: &str = "https://www.rust-lang.org/learn";
+/// const body: &[u8; 27] = b"field1=value1&field2=value2";
 ///
-///let response = request::post(uri, body, &mut writer).unwrap();
-///```
+/// let response = request::post(uri, body, &mut writer).unwrap();
+/// ```
 pub fn post<T, U>(uri: T, body: &[u8], writer: &mut U) -> Result<Response, error::Error>
 where
     T: AsRef<str>,
@@ -770,7 +767,7 @@ mod tests {
     }
 
     #[test]
-    fn request_b_parse_msg() {
+    fn request_b_parse() {
         let uri = Uri::try_from(URI).unwrap();
         let req = RequestBuilder::new(&uri);
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -510,10 +510,10 @@ impl<'a> RequestBuilder<'a> {
             let deadline = Instant::now() + timeout;
             copy_with_timeout(stream, writer, deadline)?;
         } else {
-            let num_bytes = res.content_len().unwrap_or(0);
-
-            if num_bytes > 0 {
-                copy_exact(stream, writer, num_bytes - body_part.len())?;
+            if let Some(num_bytes) = res.content_len() {
+                if num_bytes > 0 {
+                    copy_exact(stream, writer, num_bytes - body_part.len())?;
+                }
             } else {
                 io::copy(stream, writer)?;
             }

--- a/src/request.rs
+++ b/src/request.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 const CR_LF: &str = "\r\n";
-const DEFAULT_REQ_TIMEOUT: u64 = 12 * 60 * 60;
+const DEFAULT_REQ_TIMEOUT: u64 = 60 * 60;
 
 /// HTTP request methods
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -601,7 +601,7 @@ impl<'a> Request<'a> {
         });
 
         //Receive and process `head` of the response.
-        raw_response_head.receive(&receiver, deadline);
+        raw_response_head.receive(&receiver, deadline)?;
 
         let response = Response::from_head(&raw_response_head)?;
         let content_len = response.content_len().unwrap_or(1);
@@ -622,7 +622,7 @@ impl<'a> Request<'a> {
 
         //Receive and process `body`` of the response.
         if content_len > 0 {
-            writer.receive_all(&receiver, deadline);
+            writer.receive_all(&receiver, deadline)?;
         }
 
         Ok(response)
@@ -875,6 +875,16 @@ mod tests {
     }
 
     #[test]
+    fn request_timeout() {
+        let uri = Uri::try_from(URI).unwrap();
+        let mut request = Request::new(&uri);
+        let timeout = Duration::from_secs(360);
+
+        request.timeout(timeout);
+        assert_eq!(request.timeout, timeout);
+    }
+
+    #[test]
     fn request_send() {
         let mut writer = Vec::new();
         let uri = Uri::try_from(URI).unwrap();
@@ -885,7 +895,7 @@ mod tests {
 
     #[ignore]
     #[test]
-    fn request_get() {
+    fn fn_get() {
         let mut writer = Vec::new();
         let res = get(URI, &mut writer).unwrap();
 
@@ -899,7 +909,7 @@ mod tests {
 
     #[ignore]
     #[test]
-    fn request_head() {
+    fn fn_head() {
         let res = head(URI).unwrap();
         assert_ne!(res.status_code(), UNSUCCESS_CODE);
 
@@ -909,7 +919,7 @@ mod tests {
 
     #[ignore]
     #[test]
-    fn request_post() {
+    fn fn_post() {
         let mut writer = Vec::new();
         let res = post(URI, &BODY, &mut writer).unwrap();
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -568,24 +568,24 @@ impl<'a> Request<'a> {
     where
         T: Write,
     {
-        //Set up a stream.
+        // Set up a stream.
         let mut stream = Stream::new(self.inner.uri, self.connect_timeout)?;
         stream.set_read_timeout(self.read_timeout)?;
         stream.set_write_timeout(self.write_timeout)?;
         stream = Stream::try_to_https(stream, self.inner.uri, self.root_cert_file_pem)?;
 
-        //Send the request message to stream.
+        // Send the request message to stream.
         let request_msg = self.inner.parse();
         stream.write_all(&request_msg)?;
 
-        //Set up variables
+        // Set up variables
         let deadline = Instant::now() + self.timeout;
         let (sender, receiver) = mpsc::channel();
         let (sender_supp, receiver_supp) = mpsc::channel();
         let mut raw_response_head: Vec<u8> = Vec::new();
         let mut buf_reader = BufReader::new(stream);
 
-        //Read from the stream and send over data via `sender`.
+        // Read from the stream and send over data via `sender`.
         thread::spawn(move || {
             buf_reader.send_head(&sender);
 
@@ -600,7 +600,7 @@ impl<'a> Request<'a> {
             }
         });
 
-        //Receive and process `head` of the response.
+        // Receive and process `head` of the response.
         raw_response_head.receive(&receiver, deadline)?;
 
         let response = Response::from_head(&raw_response_head)?;
@@ -620,7 +620,7 @@ impl<'a> Request<'a> {
 
         sender_supp.send(params).unwrap();
 
-        //Receive and process `body`` of the response.
+        // Receive and process `body` of the response.
         if content_len > 0 {
             writer.receive_all(&receiver, deadline)?;
         }

--- a/src/request.rs
+++ b/src/request.rs
@@ -26,7 +26,9 @@ pub enum Method {
     POST,
     PUT,
     DELETE,
+    CONNECT,
     OPTIONS,
+    TRACE,
     PATCH,
 }
 
@@ -40,7 +42,9 @@ impl fmt::Display for Method {
             POST => "POST",
             PUT => "PUT",
             DELETE => "DELETE",
+            CONNECT => "CONNECT",
             OPTIONS => "OPTIONS",
+            TRACE => "TRACE",
             PATCH => "PATCH",
         };
 
@@ -300,10 +304,9 @@ impl<'a> Request<'a> {
     /// use http_req::{request::Request, uri::Uri};
     /// use std::convert::TryFrom;
     ///
-    /// let mut writer = Vec::new();
     /// let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    /// let response = Request::new(&uri).send(&mut writer).unwrap();;
+    /// let request = Request::new(&uri);
     /// ```
     pub fn new(uri: &'a Uri) -> Request<'a> {
         let mut builder = RequestBuilder::new(&uri);
@@ -328,7 +331,7 @@ impl<'a> Request<'a> {
     ///
     /// let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    /// let response = Request::new(&uri)
+    /// let request = Request::new(&uri)
     ///     .method(Method::HEAD);
     /// ```
     pub fn method<T>(&mut self, method: T) -> &mut Self
@@ -348,7 +351,7 @@ impl<'a> Request<'a> {
     ///
     /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    /// let response = Request::new(&uri)
+    /// let request = Request::new(&uri)
     ///     .version(HttpVersion::Http10);
     /// ```
 
@@ -375,7 +378,7 @@ impl<'a> Request<'a> {
     /// headers.insert("Host", "rust-lang.org");
     /// headers.insert("Connection", "Close");
     ///
-    /// let response = Request::new(&uri)
+    /// let request = Request::new(&uri)
     ///     .headers(headers);
     /// ```
     pub fn headers<T>(&mut self, headers: T) -> &mut Self
@@ -395,7 +398,7 @@ impl<'a> Request<'a> {
     ///
     /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     ///
-    /// let response = Request::new(&uri)
+    /// let request = Request::new(&uri)
     ///     .header("Accept-Language", "en-US");
     /// ```
     pub fn header<T, U>(&mut self, key: &T, val: &U) -> &mut Self
@@ -417,7 +420,7 @@ impl<'a> Request<'a> {
     /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     /// const body: &[u8; 27] = b"field1=value1&field2=value2";
     ///
-    /// let response = Request::new(&uri)
+    /// let request = Request::new(&uri)
     ///     .method(Method::POST)
     ///     .header("Content-Length", &body.len())
     ///     .body(body);
@@ -446,7 +449,7 @@ impl<'a> Request<'a> {
     /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     /// const time: Option<Duration> = Some(Duration::from_secs(10));
     ///
-    /// let response = Request::new(&uri)
+    /// let request = Request::new(&uri)
     ///     .connect_timeout(time);
     /// ```
     pub fn connect_timeout<T>(&mut self, timeout: Option<T>) -> &mut Self
@@ -472,7 +475,7 @@ impl<'a> Request<'a> {
     /// let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     /// const time: Option<Duration> = Some(Duration::from_secs(15));
     ///
-    /// let response = Request::new(&uri)
+    /// let request = Request::new(&uri)
     ///     .read_timeout(time);
     /// ```
     pub fn read_timeout<T>(&mut self, timeout: Option<T>) -> &mut Self
@@ -498,7 +501,7 @@ impl<'a> Request<'a> {
     /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     /// const time: Option<Duration> = Some(Duration::from_secs(5));
     ///
-    /// let response = Request::new(&uri)
+    /// let request = Request::new(&uri)
     ///     .write_timeout(time);
     /// ```
     pub fn write_timeout<T>(&mut self, timeout: Option<T>) -> &mut Self
@@ -520,7 +523,7 @@ impl<'a> Request<'a> {
     /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     /// const time: Duration = Duration::from_secs(5);
     ///
-    /// let response = Request::new(&uri)
+    /// let request = Request::new(&uri)
     ///     .timeout(time);
     /// ```
     pub fn timeout<T>(&mut self, timeout: T) -> &mut Self
@@ -541,7 +544,7 @@ impl<'a> Request<'a> {
     /// let uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
     /// let path = Path::new("./foo/bar.txt");
     ///
-    /// let response = Request::new(&uri)
+    /// let request = Request::new(&uri)
     ///     .root_cert_file_pem(&path);
     /// ```
     pub fn root_cert_file_pem(&mut self, file_path: &'a Path) -> &mut Self {

--- a/src/response.rs
+++ b/src/response.rs
@@ -13,9 +13,9 @@ use unicase::Ascii;
 
 pub(crate) const CR_LF_2: [u8; 4] = [13, 10, 13, 10];
 
-///Represents an HTTP response.
+/// Represents an HTTP response.
 ///
-///It contains `Headers` and `Status` parsed from response.
+/// It contains `Headers` and `Status` parsed from response.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Response {
     status: Status,
@@ -23,19 +23,19 @@ pub struct Response {
 }
 
 impl Response {
-    ///Creates new `Response` with head - status and headers - parsed from a slice of bytes
+    /// Creates new `Response` with head - status and headers - parsed from a slice of bytes
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::Response;
+    /// # Examples
+    /// ```
+    /// use http_req::response::Response;
     ///
-    ///const HEAD: &[u8; 102] = b"HTTP/1.1 200 OK\r\n\
-    ///                         Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
-    ///                         Content-Type: text/html\r\n\
-    ///                         Content-Length: 100\r\n\r\n";
+    /// const HEAD: &[u8; 102] = b"HTTP/1.1 200 OK\r\n\
+    ///                          Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
+    ///                          Content-Type: text/html\r\n\
+    ///                          Content-Length: 100\r\n\r\n";
     ///
-    ///let response = Response::from_head(HEAD).unwrap();
-    ///```
+    /// let response = Response::from_head(HEAD).unwrap();
+    /// ```
     pub fn from_head(head: &[u8]) -> Result<Response, Error> {
         let mut head = str::from_utf8(head)?.splitn(2, '\n');
 
@@ -45,21 +45,21 @@ impl Response {
         Ok(Response { status, headers })
     }
 
-    ///Parses `Response` from slice of bytes. Writes it's body to `writer`.
+    /// Parses `Response` from slice of bytes. Writes it's body to `writer`.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::Response;
+    /// # Examples
+    /// ```
+    /// use http_req::response::Response;
     ///
-    ///const RESPONSE: &[u8; 129] = b"HTTP/1.1 200 OK\r\n\
-    ///                             Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
-    ///                             Content-Type: text/html\r\n\
-    ///                             Content-Length: 100\r\n\r\n\
-    ///                             <html>hello\r\n\r\nhello</html>";
-    ///let mut body = Vec::new();
+    /// const RESPONSE: &[u8; 129] = b"HTTP/1.1 200 OK\r\n\
+    ///                              Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
+    ///                              Content-Type: text/html\r\n\
+    ///                              Content-Length: 100\r\n\r\n\
+    ///                              <html>hello\r\n\r\nhello</html>";
+    /// let mut body = Vec::new();
     ///
-    ///let response = Response::try_from(RESPONSE, &mut body).unwrap();
-    ///```
+    /// let response = Response::try_from(RESPONSE, &mut body).unwrap();
+    /// ```
     pub fn try_from<T: Write>(res: &[u8], writer: &mut T) -> Result<Response, Error> {
         if res.is_empty() {
             Err(Error::Parse(ParseErr::Empty))
@@ -76,103 +76,103 @@ impl Response {
         }
     }
 
-    ///Returns status code of this `Response`.
+    /// Returns status code of this `Response`.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::{Response, StatusCode};
+    /// # Examples
+    /// ```
+    /// use http_req::response::{Response, StatusCode};
     ///
-    ///const RESPONSE: &[u8; 129] = b"HTTP/1.1 200 OK\r\n\
-    ///                             Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
-    ///                             Content-Type: text/html\r\n\
-    ///                             Content-Length: 100\r\n\r\n\
-    ///                             <html>hello\r\n\r\nhello</html>";
-    ///let mut body = Vec::new();
+    /// const RESPONSE: &[u8; 129] = b"HTTP/1.1 200 OK\r\n\
+    ///                              Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
+    ///                              Content-Type: text/html\r\n\
+    ///                              Content-Length: 100\r\n\r\n\
+    ///                              <html>hello\r\n\r\nhello</html>";
+    /// let mut body = Vec::new();
     ///
-    ///let response = Response::try_from(RESPONSE, &mut body).unwrap();
-    ///assert_eq!(response.status_code(), StatusCode::new(200));
-    ///```
+    /// let response = Response::try_from(RESPONSE, &mut body).unwrap();
+    /// assert_eq!(response.status_code(), StatusCode::new(200));
+    /// ```
     pub const fn status_code(&self) -> StatusCode {
         self.status.code
     }
 
-    ///Returns HTTP version of this `Response`.
+    /// Returns HTTP version of this `Response`.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::Response;
+    /// # Examples
+    /// ```
+    /// use http_req::response::Response;
     ///
-    ///const RESPONSE: &[u8; 129] = b"HTTP/1.1 200 OK\r\n\
-    ///                             Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
-    ///                             Content-Type: text/html\r\n\
-    ///                             Content-Length: 100\r\n\r\n\
-    ///                             <html>hello\r\n\r\nhello</html>";
-    ///let mut body = Vec::new();
+    /// const RESPONSE: &[u8; 129] = b"HTTP/1.1 200 OK\r\n\
+    ///                              Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
+    ///                              Content-Type: text/html\r\n\
+    ///                              Content-Length: 100\r\n\r\n\
+    ///                              <html>hello\r\n\r\nhello</html>";
+    /// let mut body = Vec::new();
     ///
-    ///let response = Response::try_from(RESPONSE, &mut body).unwrap();
-    ///assert_eq!(response.version(), "HTTP/1.1");
-    ///```
+    /// let response = Response::try_from(RESPONSE, &mut body).unwrap();
+    /// assert_eq!(response.version(), "HTTP/1.1");
+    /// ```
     pub fn version(&self) -> &str {
         &self.status.version
     }
 
-    ///Returns reason of this `Response`.
+    /// Returns reason of this `Response`.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::Response;
+    /// # Examples
+    /// ```
+    /// use http_req::response::Response;
     ///
-    ///const RESPONSE: &[u8; 129] = b"HTTP/1.1 200 OK\r\n\
-    ///                             Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
-    ///                             Content-Type: text/html\r\n\
-    ///                             Content-Length: 100\r\n\r\n\
-    ///                             <html>hello\r\n\r\nhello</html>";
-    ///let mut body = Vec::new();
+    /// const RESPONSE: &[u8; 129] = b"HTTP/1.1 200 OK\r\n\
+    ///                              Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
+    ///                              Content-Type: text/html\r\n\
+    ///                              Content-Length: 100\r\n\r\n\
+    ///                              <html>hello\r\n\r\nhello</html>";
+    /// let mut body = Vec::new();
     ///
-    ///let response = Response::try_from(RESPONSE, &mut body).unwrap();
-    ///assert_eq!(response.reason(), "OK");
-    ///```
+    /// let response = Response::try_from(RESPONSE, &mut body).unwrap();
+    /// assert_eq!(response.reason(), "OK");
+    /// ```
     pub fn reason(&self) -> &str {
         &self.status.reason
     }
 
-    ///Returns headers of this `Response`.
+    /// Returns headers of this `Response`.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::Response;
+    /// # Examples
+    /// ```
+    /// use http_req::response::Response;
     ///
-    ///const RESPONSE: &[u8; 129] = b"HTTP/1.1 200 OK\r\n\
-    ///                             Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
-    ///                             Content-Type: text/html\r\n\
-    ///                             Content-Length: 100\r\n\r\n\
-    ///                             <html>hello\r\n\r\nhello</html>";
-    ///let mut body = Vec::new();
+    /// const RESPONSE: &[u8; 129] = b"HTTP/1.1 200 OK\r\n\
+    ///                              Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
+    ///                              Content-Type: text/html\r\n\
+    ///                              Content-Length: 100\r\n\r\n\
+    ///                              <html>hello\r\n\r\nhello</html>";
+    /// let mut body = Vec::new();
     ///
-    ///let response = Response::try_from(RESPONSE, &mut body).unwrap();
-    ///let headers = response.headers();
-    ///```
+    /// let response = Response::try_from(RESPONSE, &mut body).unwrap();
+    /// let headers = response.headers();
+    /// ```
     pub fn headers(&self) -> &Headers {
         &self.headers
     }
 
-    ///Returns length of the content of this `Response` as a `Option`, according to information
-    ///included in headers. If there is no such an information, returns `None`.
+    /// Returns length of the content of this `Response` as a `Option`, according to information
+    /// included in headers. If there is no such an information, returns `None`.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::Response;
+    /// # Examples
+    /// ```
+    /// use http_req::response::Response;
     ///
-    ///const RESPONSE: &[u8; 129] = b"HTTP/1.1 200 OK\r\n\
-    ///                             Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
-    ///                             Content-Type: text/html\r\n\
-    ///                             Content-Length: 100\r\n\r\n\
-    ///                             <html>hello\r\n\r\nhello</html>";
-    ///let mut body = Vec::new();
+    /// const RESPONSE: &[u8; 129] = b"HTTP/1.1 200 OK\r\n\
+    ///                              Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
+    ///                              Content-Type: text/html\r\n\
+    ///                              Content-Length: 100\r\n\r\n\
+    ///                              <html>hello\r\n\r\nhello</html>";
+    /// let mut body = Vec::new();
     ///
-    ///let response = Response::try_from(RESPONSE, &mut body).unwrap();
-    ///assert_eq!(response.content_len().unwrap(), 100);
-    ///```
+    /// let response = Response::try_from(RESPONSE, &mut body).unwrap();
+    /// assert_eq!(response.content_len().unwrap(), 100);
+    /// ```
     pub fn content_len(&self) -> Option<usize> {
         self.headers()
             .get("Content-Length")
@@ -180,7 +180,7 @@ impl Response {
     }
 }
 
-///Status of HTTP response
+/// Status of HTTP response
 #[derive(PartialEq, Debug, Clone)]
 pub struct Status {
     version: String,
@@ -226,98 +226,98 @@ impl str::FromStr for Status {
     }
 }
 
-///Wrapper around `HashMap<Ascii<String>, String>` with additional functionality for parsing HTTP headers
+/// Wrapper around `HashMap<Ascii<String>, String>` with additional functionality for parsing HTTP headers
 ///
-///# Example
-///```
-///use http_req::response::Headers;
+/// # Example
+/// ```
+/// use http_req::response::Headers;
 ///
-///let mut headers = Headers::new();
-///headers.insert("Connection", "Close");
+/// let mut headers = Headers::new();
+/// headers.insert("Connection", "Close");
 ///
-///assert_eq!(headers.get("Connection"), Some(&"Close".to_string()))
-///```
+/// assert_eq!(headers.get("Connection"), Some(&"Close".to_string()))
+/// ```
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct Headers(HashMap<Ascii<String>, String>);
 
 impl Headers {
-    ///Creates an empty `Headers`.
+    /// Creates an empty `Headers`.
     ///
-    ///The headers are initially created with a capacity of 0, so they will not allocate until
-    ///it is first inserted into.
+    /// The headers are initially created with a capacity of 0, so they will not allocate until
+    /// it is first inserted into.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::Headers;
+    /// # Examples
+    /// ```
+    /// use http_req::response::Headers;
     ///
-    ///let mut headers = Headers::new();
-    ///```
+    /// let mut headers = Headers::new();
+    /// ```
     pub fn new() -> Headers {
         Headers(HashMap::new())
     }
 
-    ///Creates empty `Headers` with the specified capacity.
+    /// Creates empty `Headers` with the specified capacity.
     ///
-    ///The headers will be able to hold at least capacity elements without reallocating.
-    ///If capacity is 0, the headers will not allocate.
+    /// The headers will be able to hold at least capacity elements without reallocating.
+    /// If capacity is 0, the headers will not allocate.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::Headers;
+    /// # Examples
+    /// ```
+    /// use http_req::response::Headers;
     ///
-    ///let mut headers = Headers::with_capacity(200);
-    ///```
+    /// let mut headers = Headers::with_capacity(200);
+    /// ```
     pub fn with_capacity(capacity: usize) -> Headers {
         Headers(HashMap::with_capacity(capacity))
     }
 
-    ///An iterator visiting all key-value pairs in arbitrary order.
-    ///The iterator's element type is `(&Ascii<String>, &String)`.
+    /// An iterator visiting all key-value pairs in arbitrary order.
+    /// The iterator's element type is `(&Ascii<String>, &String)`.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::Headers;
+    /// # Examples
+    /// ```
+    /// use http_req::response::Headers;
     ///
-    ///let mut headers = Headers::new();
-    ///headers.insert("Accept-Charset", "utf-8");
-    ///headers.insert("Accept-Language", "en-US");
-    ///headers.insert("Connection", "Close");
+    /// let mut headers = Headers::new();
+    /// headers.insert("Accept-Charset", "utf-8");
+    /// headers.insert("Accept-Language", "en-US");
+    /// headers.insert("Connection", "Close");
     ///
-    ///let mut iterator = headers.iter();
-    ///```
+    /// let mut iterator = headers.iter();
+    /// ```
     pub fn iter(&self) -> hash_map::Iter<Ascii<String>, String> {
         self.0.iter()
     }
 
-    ///Returns a reference to the value corresponding to the key.
+    /// Returns a reference to the value corresponding to the key.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::Headers;
+    /// # Examples
+    /// ```
+    /// use http_req::response::Headers;
     ///
-    ///let mut headers = Headers::new();
-    ///headers.insert("Accept-Charset", "utf-8");
+    /// let mut headers = Headers::new();
+    /// headers.insert("Accept-Charset", "utf-8");
     ///
-    ///assert_eq!(headers.get("Accept-Charset"), Some(&"utf-8".to_string()))
-    ///```
+    /// assert_eq!(headers.get("Accept-Charset"), Some(&"utf-8".to_string()))
+    /// ```
     pub fn get<T: ToString + ?Sized>(&self, k: &T) -> Option<&std::string::String> {
         self.0.get(&Ascii::new(k.to_string()))
     }
 
-    ///Inserts a key-value pair into the headers.
+    /// Inserts a key-value pair into the headers.
     ///
-    ///If the headers did not have this key present, None is returned.
+    /// If the headers did not have this key present, None is returned.
     ///
-    ///If the headers did have this key present, the value is updated, and the old value is returned.
-    ///The key is not updated, though; this matters for types that can be == without being identical.
+    /// If the headers did have this key present, the value is updated, and the old value is returned.
+    /// The key is not updated, though; this matters for types that can be == without being identical.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::Headers;
+    /// # Examples
+    /// ```
+    /// use http_req::response::Headers;
     ///
-    ///let mut headers = Headers::new();
-    ///headers.insert("Accept-Language", "en-US");
-    ///```
+    /// let mut headers = Headers::new();
+    /// headers.insert("Accept-Language", "en-US");
+    /// ```
     pub fn insert<T, U>(&mut self, key: &T, val: &U) -> Option<String>
     where
         T: ToString + ?Sized,
@@ -326,16 +326,16 @@ impl Headers {
         self.0.insert(Ascii::new(key.to_string()), val.to_string())
     }
 
-    ///Creates default headers for a HTTP request
+    /// Creates default headers for a HTTP request
     ///
-    ///# Examples
-    ///```
-    ///use http_req::{response::Headers, uri::Uri};
-    ///use std::convert::TryFrom;
+    /// # Examples
+    /// ```
+    /// use http_req::{response::Headers, uri::Uri};
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
-    ///let headers = Headers::default_http(&uri);
-    ///```
+    /// let uri: Uri = Uri::try_from("https://www.rust-lang.org/learn").unwrap();
+    /// let headers = Headers::default_http(&uri);
+    /// ```
     pub fn default_http(uri: &Uri) -> Headers {
         let mut headers = Headers::with_capacity(4);
         headers.insert("Host", &uri.host_header().unwrap_or_default());
@@ -390,118 +390,118 @@ impl fmt::Display for Headers {
     }
 }
 
-///Code sent by a server in response to a client's request.
+/// Code sent by a server in response to a client's request.
 ///
-///# Example
-///```
-///use http_req::response::StatusCode;
+/// # Example
+/// ```
+/// use http_req::response::StatusCode;
 ///
-///const code: StatusCode = StatusCode::new(200);
-///assert!(code.is_success())
-///```
+/// const code: StatusCode = StatusCode::new(200);
+/// assert!(code.is_success())
+/// ```
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct StatusCode(u16);
 
 impl StatusCode {
-    ///Creates new StatusCode from `u16` value.
+    /// Creates new StatusCode from `u16` value.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::StatusCode;
+    /// # Examples
+    /// ```
+    /// use http_req::response::StatusCode;
     ///
-    ///const code: StatusCode = StatusCode::new(200);
-    ///```
+    /// const code: StatusCode = StatusCode::new(200);
+    /// ```
     pub const fn new(code: u16) -> StatusCode {
         StatusCode(code)
     }
 
-    ///Checks if this `StatusCode` is within 100-199, which indicates that it's Informational.
+    /// Checks if this `StatusCode` is within 100-199, which indicates that it's Informational.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::StatusCode;
+    /// # Examples
+    /// ```
+    /// use http_req::response::StatusCode;
     ///
-    ///const code: StatusCode = StatusCode::new(101);
-    ///assert!(code.is_info())
-    ///```
+    /// const code: StatusCode = StatusCode::new(101);
+    /// assert!(code.is_info())
+    /// ```
     pub const fn is_info(self) -> bool {
         self.0 >= 100 && self.0 < 200
     }
 
-    ///Checks if this `StatusCode` is within 200-299, which indicates that it's Successful.
+    /// Checks if this `StatusCode` is within 200-299, which indicates that it's Successful.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::StatusCode;
+    /// # Examples
+    /// ```
+    /// use http_req::response::StatusCode;
     ///
-    ///const code: StatusCode = StatusCode::new(204);
-    ///assert!(code.is_success())
-    ///```
+    /// const code: StatusCode = StatusCode::new(204);
+    /// assert!(code.is_success())
+    /// ```
     pub const fn is_success(self) -> bool {
         self.0 >= 200 && self.0 < 300
     }
 
-    ///Checks if this `StatusCode` is within 300-399, which indicates that it's Redirection.
+    /// Checks if this `StatusCode` is within 300-399, which indicates that it's Redirection.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::StatusCode;
+    /// # Examples
+    /// ```
+    /// use http_req::response::StatusCode;
     ///
-    ///const code: StatusCode = StatusCode::new(301);
-    ///assert!(code.is_redirect())
-    ///```
+    /// const code: StatusCode = StatusCode::new(301);
+    /// assert!(code.is_redirect())
+    /// ```
     pub const fn is_redirect(self) -> bool {
         self.0 >= 300 && self.0 < 400
     }
 
-    ///Checks if this `StatusCode` is within 400-499, which indicates that it's Client Error.
+    /// Checks if this `StatusCode` is within 400-499, which indicates that it's Client Error.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::StatusCode;
+    /// # Examples
+    /// ```
+    /// use http_req::response::StatusCode;
     ///
-    ///const code: StatusCode = StatusCode::new(400);
-    ///assert!(code.is_client_err())
-    ///```
+    /// const code: StatusCode = StatusCode::new(400);
+    /// assert!(code.is_client_err())
+    /// ```
     pub const fn is_client_err(self) -> bool {
         self.0 >= 400 && self.0 < 500
     }
 
-    ///Checks if this `StatusCode` is within 500-599, which indicates that it's Server Error.
+    /// Checks if this `StatusCode` is within 500-599, which indicates that it's Server Error.
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::StatusCode;
+    /// # Examples
+    /// ```
+    /// use http_req::response::StatusCode;
     ///
-    ///const code: StatusCode = StatusCode::new(503);
-    ///assert!(code.is_server_err())
-    ///```
+    /// const code: StatusCode = StatusCode::new(503);
+    /// assert!(code.is_server_err())
+    /// ```
     pub const fn is_server_err(self) -> bool {
         self.0 >= 500 && self.0 < 600
     }
 
-    ///Checks this `StatusCode` using closure `f`
+    /// Checks this `StatusCode` using closure `f`
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::StatusCode;
+    /// # Examples
+    /// ```
+    /// use http_req::response::StatusCode;
     ///
-    ///const code: StatusCode = StatusCode::new(203);
-    ///assert!(code.is(|i| i > 199 && i < 250))
-    ///```
+    /// const code: StatusCode = StatusCode::new(203);
+    /// assert!(code.is(|i| i > 199 && i < 250))
+    /// ```
     pub fn is<F: FnOnce(u16) -> bool>(self, f: F) -> bool {
         f(self.0)
     }
 
-    ///Returns `Reason-Phrase` corresponding to this `StatusCode`
+    /// Returns `Reason-Phrase` corresponding to this `StatusCode`
     ///
-    ///# Examples
-    ///```
-    ///use http_req::response::StatusCode;
+    /// # Examples
+    /// ```
+    /// use http_req::response::StatusCode;
     ///
-    ///const code: StatusCode = StatusCode::new(200);
-    ///assert_eq!(code.reason(), Some("OK"))
-    ///```
+    /// const code: StatusCode = StatusCode::new(200);
+    /// assert_eq!(code.reason(), Some("OK"))
+    /// ```
     pub const fn reason(self) -> Option<&'static str> {
         let reason = match self.0 {
             100 => "Continue",
@@ -601,7 +601,7 @@ impl str::FromStr for StatusCode {
     }
 }
 
-///Finds elements slice `e` inside slice `data`. Returns position of the end of first match.
+/// Finds elements slice `e` inside slice `data`. Returns position of the end of first match.
 pub fn find_slice<T>(data: &[T], e: &[T]) -> Option<usize>
 where
     [T]: PartialEq,

--- a/src/response.rs
+++ b/src/response.rs
@@ -226,7 +226,7 @@ impl str::FromStr for Status {
     }
 }
 
-///Wrapper around HashMap<Ascii<String>, String> with additional functionality for parsing HTTP headers
+///Wrapper around `HashMap<Ascii<String>, String>` with additional functionality for parsing HTTP headers
 ///
 ///# Example
 ///```
@@ -272,7 +272,7 @@ impl Headers {
     }
 
     ///An iterator visiting all key-value pairs in arbitrary order.
-    ///The iterator's element type is (&Ascii<String>, &String).
+    ///The iterator's element type is `(&Ascii<String>, &String)`.
     ///
     ///# Examples
     ///```

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -226,11 +226,14 @@ where
 /// Exexcutes a function in a loop until operation is completed or deadline is exceeded.
 ///
 /// It checks if a timeout was exceeded every iteration, therefore it limits
-/// how many time a specific function can be called before deadline.
-/// However a deadline may be exceeded if a single function call takes too much time.
-///
-/// Function `func` needs to return `true` when the operation is complete.
-///
+/// how many time a specific function can be called before deadline. 
+/// For the `execute_with_deadline` to meet the deadline, each call 
+/// to `func` needs finish before the deadline. 
+/// 
+/// Key information about function `func`:
+/// - is provided with information about remaining time
+/// - must ensure that its execution will not take more time than specified in `remaining_time`
+/// - needs to return `true` when the operation is complete
 pub fn execute_with_deadline<F>(deadline: Instant, mut func: F)
 where
     F: FnMut(Duration) -> bool,
@@ -247,8 +250,8 @@ where
 
 /// Reads the head of HTTP response from `reader`.
 ///
-/// Reads from `reader` (line by line) until a blank line is found
-/// indicating that all meta-information for the request has been sent.
+/// Reads from `reader` (line by line) until a blank line is identified, 
+/// which indicates that all meta-information has been read,
 pub fn read_head<B>(reader: &mut B) -> Vec<u8>
 where
     B: BufRead,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,51 @@
+use crate::error::Error;
+use std::io;
+use std::net::TcpStream;
+use std::time::Duration;
+
+use crate::tls::Conn;
+
+pub enum Stream {
+    Http(TcpStream),
+    Https(Conn<TcpStream>),
+}
+
+impl Stream {
+    pub fn set_read_timeout(&mut self, dur: Option<Duration>) -> Result<(), Error> {
+        match self {
+            Stream::Http(stream) => Ok(stream.set_read_timeout(dur)?),
+            Stream::Https(_) => Err(Error::Tls),
+        }
+    }
+
+    pub fn set_write_timeout(&mut self, dur: Option<Duration>) -> Result<(), Error> {
+        match self {
+            Stream::Http(stream) => Ok(stream.set_write_timeout(dur)?),
+            Stream::Https(_) => Err(Error::Tls),
+        }
+    }
+}
+
+impl io::Read for Stream {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
+        match self {
+            Stream::Http(stream) => stream.read(buf),
+            Stream::Https(stream) => stream.read(buf),
+        }
+    }
+}
+
+impl io::Write for Stream {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
+        match self {
+            Stream::Http(stream) => stream.write(buf),
+            Stream::Https(stream) => stream.write(buf),
+        }
+    }
+    fn flush(&mut self) -> Result<(), io::Error> {
+        match self {
+            Stream::Http(stream) => stream.flush(),
+            Stream::Https(stream) => stream.flush(),
+        }
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-const BUF_SIZE: usize = 1024 * 1024;
+const BUF_SIZE: usize = 16 * 1000;
 
 /// Wrapper around TCP stream for HTTP and HTTPS protocols.
 /// Allows to perform common operations on underlying stream.
@@ -124,12 +124,12 @@ where
 
     fn send_all(&mut self, sender: &Sender<Vec<u8>>) {
         loop {
-            let mut buf = vec![0; BUF_SIZE];
+            let mut buf = [0; BUF_SIZE];
 
             match self.read(&mut buf) {
                 Ok(0) | Err(_) => break,
                 Ok(len) => {
-                    let filled_buf = buf[..len].to_owned();
+                    let filled_buf = buf[..len].to_vec();
                     sender.send(filled_buf).unwrap();
                 }
             }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,7 +1,14 @@
-use crate::error::Error;
-use std::io;
-use std::net::TcpStream;
-use std::time::Duration;
+use crate::{
+    error::Error,
+    tls,
+    uri::Uri,
+};
+use std::{
+    io,
+    net::{TcpStream, ToSocketAddrs},
+    path::Path,
+    time::Duration,
+};
 
 use crate::tls::Conn;
 
@@ -11,6 +18,42 @@ pub enum Stream {
 }
 
 impl Stream {
+    pub fn default(
+        uri: &Uri,
+        connect_timeout: Option<Duration>,
+        read_timeout: Option<Duration>,
+        write_timeout: Option<Duration>,
+        root_cert_file_pem: Option<&Path>,
+    ) -> Result<Stream, Error> {
+        let host = uri.host().unwrap_or("");
+        let port = uri.corr_port();
+        let scheme = uri.scheme();
+
+        let mut stream = new_http(host, port, connect_timeout)?;
+        stream.set_read_timeout(read_timeout)?;
+        stream.set_write_timeout(write_timeout)?;
+
+        if scheme == "https" {
+            if let Stream::Http(inner_stream) = stream {
+                stream = to_https(inner_stream, host, root_cert_file_pem)?;
+            };
+        };
+
+        Ok(stream)
+    }
+
+    /*pub fn new(uri: &Uri, connect_timeout: Option<Duration>) -> Result<Stream, Error> {
+        let host = uri.host().unwrap_or("");
+        let port = uri.corr_port();
+
+        let stream = match connect_timeout {
+            Some(timeout) => connect_with_timeout(host, port, timeout)?,
+            None => TcpStream::connect((host, port))?,
+        };
+
+        Ok(Stream::Http(stream))
+    }*/
+
     pub fn set_read_timeout(&mut self, dur: Option<Duration>) -> Result<(), Error> {
         match self {
             Stream::Http(stream) => Ok(stream.set_read_timeout(dur)?),
@@ -48,4 +91,60 @@ impl io::Write for Stream {
             Stream::Https(stream) => stream.flush(),
         }
     }
+}
+
+pub fn new_http(host: &str, port: u16, connect_timeout: Option<Duration>) -> Result<Stream, Error> {
+    let stream = match connect_timeout {
+        Some(timeout) => connect_with_timeout(host, port, timeout)?,
+        None => TcpStream::connect((host, port))?,
+    };
+
+    Ok(Stream::Http(stream))
+}
+
+pub fn to_https(
+    http_stream: TcpStream,
+    host: &str,
+    root_cert_file_pem: Option<&Path>,
+) -> Result<Stream, Error> {
+    let mut cnf = tls::Config::default();
+
+    let cnf = match root_cert_file_pem {
+        Some(p) => cnf.add_root_cert_file_pem(p)?,
+        None => &mut cnf,
+    };
+
+    let stream = cnf.connect(host, http_stream)?;
+    Ok(Stream::Https(stream))
+}
+
+///Connects to target host with a timeout
+pub fn connect_with_timeout<T, U>(host: T, port: u16, timeout: U) -> io::Result<TcpStream>
+where
+    Duration: From<U>,
+    T: AsRef<str>,
+{
+    let host = host.as_ref();
+    let timeout = Duration::from(timeout);
+    let addrs: Vec<_> = (host, port).to_socket_addrs()?.collect();
+    let count = addrs.len();
+
+    for (idx, addr) in addrs.into_iter().enumerate() {
+        match TcpStream::connect_timeout(&addr, timeout) {
+            Ok(stream) => return Ok(stream),
+            Err(err) => match err.kind() {
+                io::ErrorKind::TimedOut => return Err(err),
+                _ => {
+                    if idx + 1 == count {
+                        return Err(err);
+                    }
+                }
+            },
+        };
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::AddrNotAvailable,
+        format!("Could not resolve address for {:?}", host),
+    ))
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,4 +1,6 @@
-use crate::{error::Error, tls, tls::Conn, uri::Uri};
+//! TCP stream
+
+use crate::{error::Error, tls, tls::Conn, uri::Uri, CR_LF, LF};
 use std::{
     io::{self, BufRead, Read, Write},
     net::{TcpStream, ToSocketAddrs},
@@ -7,16 +9,17 @@ use std::{
     time::{Duration, Instant},
 };
 
-const CR_LF: &str = "\r\n";
 const BUF_SIZE: usize = 1024 * 1024;
-const RECEIVING_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Wrapper around TCP stream for HTTP and HTTPS protocols.
+/// Allows to perform common operations on underlying stream.
 pub enum Stream {
     Http(TcpStream),
     Https(Conn<TcpStream>),
 }
 
 impl Stream {
+    /// Opens a TCP connection to a remote host with a connection timeout (if specified).
     pub fn new(uri: &Uri, connect_timeout: Option<Duration>) -> Result<Stream, Error> {
         let host = uri.host().unwrap_or("");
         let port = uri.corr_port();
@@ -29,6 +32,11 @@ impl Stream {
         Ok(Stream::Http(stream))
     }
 
+    /// Tries to establish a secure connection over TLS.
+    ///
+    /// Checks if `uri` scheme denotes a HTTPS protocol:
+    /// - If yes, attemps to establish a secure connection
+    /// - Otherwise, returns the `stream` without any modification
     pub fn try_to_https(
         stream: Stream,
         uri: &Uri,
@@ -55,17 +63,19 @@ impl Stream {
         }
     }
 
+    /// Sets the read timeout on the underlying TCP stream.
     pub fn set_read_timeout(&mut self, dur: Option<Duration>) -> Result<(), Error> {
         match self {
             Stream::Http(stream) => Ok(stream.set_read_timeout(dur)?),
-            Stream::Https(_) => Err(Error::Tls),
+            Stream::Https(conn) => Ok(conn.get_mut().set_read_timeout(dur)?),
         }
     }
 
+    /// Sets the write timeout on the underlying TCP stream.
     pub fn set_write_timeout(&mut self, dur: Option<Duration>) -> Result<(), Error> {
         match self {
             Stream::Http(stream) => Ok(stream.set_write_timeout(dur)?),
-            Stream::Https(_) => Err(Error::Tls),
+            Stream::Https(conn) => Ok(conn.get_mut().set_write_timeout(dur)?),
         }
     }
 }
@@ -95,33 +105,23 @@ impl Write for Stream {
 }
 
 pub trait ThreadSend {
-    fn read_head(&mut self, sender: &Sender<Vec<u8>>);
-    fn read_body(&mut self, sender: &Sender<Vec<u8>>);
+    /// Reads `head` of the response and sends it via `sender`
+    fn send_head(&mut self, sender: &Sender<Vec<u8>>);
+
+    /// Reads all bytes until EOF and sends them via `sender`
+    fn send_all(&mut self, sender: &Sender<Vec<u8>>);
 }
 
 impl<T> ThreadSend for T
 where
     T: BufRead,
 {
-    fn read_head(&mut self, sender: &Sender<Vec<u8>>) {
-        loop {
-            let mut buf = Vec::new();
-
-            match self.read_until(0xA, &mut buf) {
-                Ok(0) | Err(_) => break,
-                Ok(len) => {
-                    let filled_buf = buf[..len].to_owned();
-                    sender.send(filled_buf).unwrap();
-
-                    if len == 2 && buf == CR_LF.as_bytes() {
-                        break;
-                    }
-                }
-            }
-        }
+    fn send_head(&mut self, sender: &Sender<Vec<u8>>) {
+        let buf = read_head(self);
+        sender.send(buf).unwrap();
     }
 
-    fn read_body(&mut self, sender: &Sender<Vec<u8>>) {
+    fn send_all(&mut self, sender: &Sender<Vec<u8>>) {
         loop {
             let mut buf = vec![0; BUF_SIZE];
 
@@ -137,50 +137,48 @@ where
 }
 
 pub trait ThreadReceive {
-    fn write_head(&mut self, receiver: &Receiver<Vec<u8>>, deadline: Instant);
-    fn write_body(&mut self, receiver: &Receiver<Vec<u8>>, deadline: Instant);
+    /// Receives data from `receiver` and writes them into this writer.
+    /// Fails if `deadline` is exceeded.
+    fn receive(&mut self, receiver: &Receiver<Vec<u8>>, deadline: Instant);
+
+    /// Continuosly receives data from `receiver` until there is no more data
+    /// or `deadline` is exceeded. Writes received data into this writer.
+    fn receive_all(&mut self, receiver: &Receiver<Vec<u8>>, deadline: Instant);
 }
 
 impl<T> ThreadReceive for T
 where
     T: Write,
 {
-    fn write_head(&mut self, receiver: &Receiver<Vec<u8>>, deadline: Instant) {
-        execute_with_deadline(deadline, || {
-            let mut continue_reading = true;
-
-            let data_read = match receiver.recv_timeout(RECEIVING_TIMEOUT) {
+    fn receive(&mut self, receiver: &Receiver<Vec<u8>>, deadline: Instant) {
+        execute_with_deadline(deadline, |remaining_time| {
+            let data_read = match receiver.recv_timeout(remaining_time) {
                 Ok(data) => data,
-                Err(_) => return false,
+                Err(_) => return true,
             };
 
-            if data_read == CR_LF.as_bytes() {
-                continue_reading = false;
-            }
-
             self.write_all(&data_read).unwrap();
-
-            continue_reading
+            true
         });
     }
 
-    fn write_body(&mut self, receiver: &Receiver<Vec<u8>>, deadline: Instant) {
-        execute_with_deadline(deadline, || {
-            let continue_reading = true;
+    fn receive_all(&mut self, receiver: &Receiver<Vec<u8>>, deadline: Instant) {
+        execute_with_deadline(deadline, |remaining_time| {
+            let is_complete = false;
 
-            let data_read = match receiver.recv_timeout(RECEIVING_TIMEOUT) {
+            let data_read = match receiver.recv_timeout(remaining_time) {
                 Ok(data) => data,
-                Err(_) => return false,
+                Err(_) => return true,
             };
 
             self.write_all(&data_read).unwrap();
 
-            continue_reading
+            is_complete
         });
     }
 }
 
-///Connects to target host with a timeout
+/// Connects to the target host with a specified timeout.
 pub fn connect_with_timeout<T, U>(host: T, port: u16, timeout: U) -> io::Result<TcpStream>
 where
     Duration: From<U>,
@@ -211,15 +209,46 @@ where
     ))
 }
 
+/// Exexcutes a function in a loop until operation is completed
+/// or deadline is reached.
+///
+/// Function `func` needs to return `true` when the operation is complete.
 pub fn execute_with_deadline<F>(deadline: Instant, mut func: F)
 where
-    F: FnMut() -> bool,
+    F: FnMut(Duration) -> bool,
 {
     loop {
         let now = Instant::now();
+        let remaining_time = deadline - now;
 
-        if deadline < now || func() == false {
+        if deadline < now || func(remaining_time) == true {
             break;
         }
     }
+}
+
+/// Reads the head of HTTP response from `reader`.
+///
+/// Reads from `reader` (line by line) until a blank line is found
+/// indicating that all meta-information for the request has been sent.
+pub fn read_head<B>(reader: &mut B) -> Vec<u8>
+where
+    B: BufRead,
+{
+    let mut buf = Vec::with_capacity(BUF_SIZE);
+
+    loop {
+        match reader.read_until(LF, &mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(len) => {
+                let full_len = buf.len();
+
+                if len == 2 && &buf[full_len - 2..] == CR_LF {
+                    break;
+                }
+            }
+        }
+    }
+
+    buf
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,4 +1,4 @@
-//!secure connection over TLS
+//! secure connection over TLS
 
 use crate::error::Error as HttpError;
 use std::{
@@ -16,14 +16,30 @@ use crate::error::ParseErr;
 #[cfg(not(any(feature = "native-tls", feature = "rust-tls")))]
 compile_error!("one of the `native-tls` or `rust-tls` features must be enabled");
 
-///wrapper around TLS Stream,
-///depends on selected TLS library
+/// Wrapper around TLS Stream, depends on selected TLS library (`S: io::Read + io::Write`):
+/// - native_tls: `TlsStream<S>`
+/// - rustls: `StreamOwned<ClientConnection, S>`
 pub struct Conn<S: io::Read + io::Write> {
     #[cfg(feature = "native-tls")]
     stream: native_tls::TlsStream<S>,
 
     #[cfg(feature = "rust-tls")]
     stream: rustls::StreamOwned<rustls::ClientConnection, S>,
+}
+
+impl<S> Conn<S>
+where
+    S: io::Read + io::Write,
+{
+    /// Returns a reference to the underlying socket
+    pub fn get_ref(&self) -> &S {
+        self.stream.get_ref()
+    }
+
+    /// Returns a mutable reference to the underlying socket
+    pub fn get_mut(&mut self) -> &mut S {
+        self.stream.get_mut()
+    }
 }
 
 impl<S: io::Read + io::Write> io::Read for Conn<S> {
@@ -58,7 +74,7 @@ impl<S: io::Read + io::Write> io::Write for Conn<S> {
     }
 }
 
-///client configuration
+/// Client configuration for TLS connection.
 pub struct Config {
     #[cfg(feature = "native-tls")]
     extra_root_certs: Vec<native_tls::Certificate>,
@@ -84,6 +100,7 @@ impl Default for Config {
                 ta.name_constraints,
             )
         }));
+
         Config {
             root_certs: std::sync::Arc::new(root_store),
         }
@@ -96,17 +113,20 @@ impl Config {
         let f = File::open(file_path)?;
         let f = BufReader::new(f);
         let mut pem_crt = vec![];
+
         for line in f.lines() {
             let line = line?;
             let is_end_cert = line.contains("-----END");
             pem_crt.append(&mut line.into_bytes());
             pem_crt.push(b'\n');
+
             if is_end_cert {
                 let crt = native_tls::Certificate::from_pem(&pem_crt)?;
                 self.extra_root_certs.push(crt);
                 pem_crt.clear();
             }
         }
+
         Ok(self)
     }
 
@@ -117,9 +137,11 @@ impl Config {
         S: io::Read + io::Write,
     {
         let mut connector_builder = native_tls::TlsConnector::builder();
+
         for crt in self.extra_root_certs.iter() {
             connector_builder.add_root_certificate((*crt).clone());
         }
+
         let connector = connector_builder.build()?;
         let stream = connector.connect(hostname.as_ref(), stream)?;
 
@@ -130,8 +152,10 @@ impl Config {
     pub fn add_root_cert_file_pem(&mut self, file_path: &Path) -> Result<&mut Self, HttpError> {
         let f = File::open(file_path)?;
         let mut f = BufReader::new(f);
+
         let root_certs = std::sync::Arc::make_mut(&mut self.root_certs);
         root_certs.add_parsable_certificates(&rustls_pemfile::certs(&mut f)?);
+
         Ok(self)
     }
 
@@ -147,11 +171,13 @@ impl Config {
             .with_safe_defaults()
             .with_root_certificates(self.root_certs.clone())
             .with_no_client_auth();
+
         let session = ClientConnection::new(
             std::sync::Arc::new(client_config),
             hostname.as_ref().try_into().map_err(|_| HttpError::Tls)?,
         )
         .map_err(|e| ParseErr::Rustls(e))?;
+
         let stream = StreamOwned::new(session, stream);
 
         Ok(Conn { stream })

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -10,9 +10,6 @@ use std::{
 #[cfg(feature = "native-tls")]
 use std::io::prelude::*;
 
-#[cfg(feature = "rust-tls")]
-use crate::error::ParseErr;
-
 #[cfg(not(any(feature = "native-tls", feature = "rust-tls")))]
 compile_error!("one of the `native-tls` or `rust-tls` features must be enabled");
 
@@ -176,7 +173,7 @@ impl Config {
             std::sync::Arc::new(client_config),
             hostname.as_ref().try_into().map_err(|_| HttpError::Tls)?,
         )
-        .map_err(|e| ParseErr::Rustls(e))?;
+        .map_err(|_| HttpError::Tls)?;
 
         let stream = StreamOwned::new(session, stream);
 

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -11,7 +11,7 @@ use std::{
 const HTTP_PORT: u16 = 80;
 const HTTPS_PORT: u16 = 443;
 
-///A (half-open) range bounded inclusively below and exclusively above (start..end) with `Copy`.
+/// A (half-open) range bounded inclusively below and exclusively above (start..end) with `Copy`.
 #[derive(Copy, Clone, Debug, PartialOrd, PartialEq)]
 pub struct RangeC {
     pub start: usize,
@@ -19,14 +19,14 @@ pub struct RangeC {
 }
 
 impl RangeC {
-    ///Creates new `RangeC` with `start` and `end`.
+    /// Creates new `RangeC` with `start` and `end`.
     ///
-    ///# Exmaples
-    ///```
-    ///use http_req::uri::RangeC;
+    /// # Exmaples
+    /// ```
+    /// use http_req::uri::RangeC;
     ///
-    ///const range: RangeC = RangeC::new(0, 20);
-    ///```
+    /// const range: RangeC = RangeC::new(0, 20);
+    /// ```
     pub const fn new(start: usize, end: usize) -> RangeC {
         RangeC { start, end }
     }
@@ -59,16 +59,16 @@ impl Index<RangeC> for String {
     }
 }
 
-///Representation of Uniform Resource Identifier
+/// Representation of Uniform Resource Identifier
 ///
-///# Example
-///```
-///use http_req::uri::Uri;
-///use std::convert::TryFrom;
+/// # Example
+/// ```
+/// use http_req::uri::Uri;
+/// use std::convert::TryFrom;
 ///
-///let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
-///assert_eq!(uri.host(), Some("foo.com"));
-///```
+/// let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
+/// assert_eq!(uri.host(), Some("foo.com"));
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct Uri<'a> {
     inner: &'a str,
@@ -80,58 +80,58 @@ pub struct Uri<'a> {
 }
 
 impl<'a> Uri<'a> {
-    ///Returns scheme of this `Uri`.
+    /// Returns scheme of this `Uri`.
     ///
-    ///# Example
-    ///```
-    ///use http_req::uri::Uri;
-    ///use std::convert::TryFrom;
+    /// # Example
+    /// ```
+    /// use http_req::uri::Uri;
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
-    ///assert_eq!(uri.scheme(), "https");
-    ///```
+    /// let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
+    /// assert_eq!(uri.scheme(), "https");
+    /// ```
     pub fn scheme(&self) -> &str {
         &self.inner[self.scheme]
     }
 
-    ///Returns information about the user included in this `Uri`.
-    ///     
-    ///# Example
-    ///```
-    ///use http_req::uri::Uri;
-    ///use std::convert::TryFrom;
+    /// Returns information about the user included in this `Uri`.
+    ///      
+    /// # Example
+    /// ```
+    /// use http_req::uri::Uri;
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
-    ///assert_eq!(uri.user_info(), Some("user:info"));
-    ///```
+    /// let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
+    /// assert_eq!(uri.user_info(), Some("user:info"));
+    /// ```
     pub fn user_info(&self) -> Option<&str> {
         self.authority.as_ref().and_then(|a| a.user_info())
     }
 
-    ///Returns host of this `Uri`.
-    ///     
-    ///# Example
-    ///```
-    ///use http_req::uri::Uri;
-    ///use std::convert::TryFrom;
+    /// Returns host of this `Uri`.
+    ///      
+    /// # Example
+    /// ```
+    /// use http_req::uri::Uri;
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
-    ///assert_eq!(uri.host(), Some("foo.com"));
-    ///```
+    /// let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
+    /// assert_eq!(uri.host(), Some("foo.com"));
+    /// ```
     pub fn host(&self) -> Option<&str> {
         self.authority.as_ref().map(|a| a.host())
     }
 
-    ///Returns host of this `Uri` to use in a header.
-    ///     
-    ///# Example
-    ///```
-    ///use http_req::uri::Uri;
-    ///use std::convert::TryFrom;
+    /// Returns host of this `Uri` to use in a header.
+    ///      
+    /// # Example
+    /// ```
+    /// use http_req::uri::Uri;
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
-    ///assert_eq!(uri.host_header(), Some("foo.com:12".to_string()));
-    ///```
+    /// let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
+    /// assert_eq!(uri.host_header(), Some("foo.com:12".to_string()));
+    /// ```
     pub fn host_header(&self) -> Option<String> {
         self.host().map(|h| match self.corr_port() {
             HTTP_PORT | HTTPS_PORT => h.to_string(),
@@ -139,31 +139,31 @@ impl<'a> Uri<'a> {
         })
     }
 
-    ///Returns port of this `Uri`
-    ///     
-    ///# Example
-    ///```
-    ///use http_req::uri::Uri;
-    ///use std::convert::TryFrom;
+    /// Returns port of this `Uri`
+    ///      
+    /// # Example
+    /// ```
+    /// use http_req::uri::Uri;
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
-    ///assert_eq!(uri.port(), Some(12));
-    ///```
+    /// let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
+    /// assert_eq!(uri.port(), Some(12));
+    /// ```
     pub fn port(&self) -> Option<u16> {
         self.authority.as_ref().and_then(|a| a.port())
     }
 
-    ///Returns port corresponding to this `Uri`.
-    ///Returns default port if it hasn't been set in the uri.
-    ///  
-    ///# Example
-    ///```
-    ///use http_req::uri::Uri;
-    ///use std::convert::TryFrom;
+    /// Returns port corresponding to this `Uri`.
+    /// Returns default port if it hasn't been set in the uri.
+    ///   
+    /// # Example
+    /// ```
+    /// use http_req::uri::Uri;
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
-    ///assert_eq!(uri.corr_port(), 12);
-    ///```
+    /// let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
+    /// assert_eq!(uri.corr_port(), 12);
+    /// ```
     pub fn corr_port(&self) -> u16 {
         let default_port = match self.scheme() {
             "https" => HTTPS_PORT,
@@ -176,58 +176,58 @@ impl<'a> Uri<'a> {
         }
     }
 
-    ///Returns path of this `Uri`.
-    ///  
-    ///# Example
-    ///```
-    ///use http_req::uri::Uri;
-    ///use std::convert::TryFrom;
+    /// Returns path of this `Uri`.
+    ///   
+    /// # Example
+    /// ```
+    /// use http_req::uri::Uri;
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
-    ///assert_eq!(uri.path(), Some("/bar/baz"));
-    ///```
+    /// let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
+    /// assert_eq!(uri.path(), Some("/bar/baz"));
+    /// ```
     pub fn path(&self) -> Option<&str> {
         self.path.map(|r| &self.inner[r])
     }
 
-    ///Returns query of this `Uri`.
-    ///  
-    ///# Example
-    ///```
-    ///use http_req::uri::Uri;
-    ///use std::convert::TryFrom;
+    /// Returns query of this `Uri`.
+    ///   
+    /// # Example
+    /// ```
+    /// use http_req::uri::Uri;
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
-    ///assert_eq!(uri.query(), Some("query"));
-    ///```
+    /// let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
+    /// assert_eq!(uri.query(), Some("query"));
+    /// ```
     pub fn query(&self) -> Option<&str> {
         self.query.map(|r| &self.inner[r])
     }
 
-    ///Returns fragment of this `Uri`.
-    ///  
-    ///# Example
-    ///```
-    ///use http_req::uri::Uri;
-    ///use std::convert::TryFrom;
+    /// Returns fragment of this `Uri`.
+    ///   
+    /// # Example
+    /// ```
+    /// use http_req::uri::Uri;
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
-    ///assert_eq!(uri.fragment(), Some("fragment"));
-    ///```
+    /// let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
+    /// assert_eq!(uri.fragment(), Some("fragment"));
+    /// ```
     pub fn fragment(&self) -> Option<&str> {
         self.fragment.map(|r| &self.inner[r])
     }
 
-    ///Returns resource `Uri` points to.
-    ///  
-    ///# Example
-    ///```
-    ///use http_req::uri::Uri;
-    ///use std::convert::TryFrom;
+    /// Returns resource `Uri` points to.
+    ///   
+    /// # Example
+    /// ```
+    /// use http_req::uri::Uri;
+    /// use std::convert::TryFrom;
     ///
-    ///let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
-    ///assert_eq!(uri.resource(), "/bar/baz?query#fragment");
-    ///```
+    /// let uri: Uri = Uri::try_from("https://user:info@foo.com:12/bar/baz?query#fragment").unwrap();;
+    /// assert_eq!(uri.resource(), "/bar/baz?query#fragment");
+    /// ```
     pub fn resource(&self) -> &str {
         match self.path {
             Some(p) => &self.inner[p.start..],
@@ -301,16 +301,16 @@ impl<'a> TryFrom<&'a str> for Uri<'a> {
     }
 }
 
-///Authority of Uri
+/// Authority of Uri
 ///
-///# Example
-///```
-///use http_req::uri::Authority;
-///use std::convert::TryFrom;
+/// # Example
+/// ```
+/// use http_req::uri::Authority;
+/// use std::convert::TryFrom;
 ///
-///let auth: Authority = Authority::try_from("user:info@foo.com:443").unwrap();
-///assert_eq!(auth.host(), "foo.com");
-///```
+/// let auth: Authority = Authority::try_from("user:info@foo.com:443").unwrap();
+/// assert_eq!(auth.host(), "foo.com");
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct Authority<'a> {
     inner: &'a str,
@@ -321,44 +321,44 @@ pub struct Authority<'a> {
 }
 
 impl<'a> Authority<'a> {
-    ///Returns username of this `Authority`
+    /// Returns username of this `Authority`
     ///
-    ///# Example
-    ///```
-    ///use http_req::uri::Authority;
-    ///use std::convert::TryFrom;
+    /// # Example
+    /// ```
+    /// use http_req::uri::Authority;
+    /// use std::convert::TryFrom;
     ///
-    ///let auth: Authority = Authority::try_from("user:info@foo.com:443").unwrap();
-    ///assert_eq!(auth.username(), Some("user"));
-    ///```
+    /// let auth: Authority = Authority::try_from("user:info@foo.com:443").unwrap();
+    /// assert_eq!(auth.username(), Some("user"));
+    /// ```
     pub fn username(&self) -> Option<&'a str> {
         self.username.map(|r| &self.inner[r])
     }
 
-    ///Returns password of this `Authority`
+    /// Returns password of this `Authority`
     ///
-    ///# Example
-    ///```
-    ///use http_req::uri::Authority;
-    ///use std::convert::TryFrom;
+    /// # Example
+    /// ```
+    /// use http_req::uri::Authority;
+    /// use std::convert::TryFrom;
     ///
-    ///let auth: Authority = Authority::try_from("user:info@foo.com:443").unwrap();
-    ///assert_eq!(auth.password(), Some("info"));
-    ///```
+    /// let auth: Authority = Authority::try_from("user:info@foo.com:443").unwrap();
+    /// assert_eq!(auth.password(), Some("info"));
+    /// ```
     pub fn password(&self) -> Option<&str> {
         self.password.map(|r| &self.inner[r])
     }
 
-    ///Returns information about the user
+    /// Returns information about the user
     ///
-    ///# Example
-    ///```
-    ///use http_req::uri::Authority;
-    ///use std::convert::TryFrom;
+    /// # Example
+    /// ```
+    /// use http_req::uri::Authority;
+    /// use std::convert::TryFrom;
     ///
-    ///let auth: Authority = Authority::try_from("user:info@foo.com:443").unwrap();
-    ///assert_eq!(auth.user_info(), Some("user:info"));
-    ///```
+    /// let auth: Authority = Authority::try_from("user:info@foo.com:443").unwrap();
+    /// assert_eq!(auth.user_info(), Some("user:info"));
+    /// ```
     pub fn user_info(&self) -> Option<&str> {
         match (&self.username, &self.password) {
             (Some(u), Some(p)) => Some(&self.inner[u.start..p.end]),
@@ -367,30 +367,30 @@ impl<'a> Authority<'a> {
         }
     }
 
-    ///Returns host of this `Authority`
+    /// Returns host of this `Authority`
     ///
-    ///# Example
-    ///```
-    ///use http_req::uri::Authority;
-    ///use std::convert::TryFrom;
+    /// # Example
+    /// ```
+    /// use http_req::uri::Authority;
+    /// use std::convert::TryFrom;
     ///
-    ///let auth: Authority = Authority::try_from("user:info@foo.com:443").unwrap();
-    ///assert_eq!(auth.host(), "foo.com");
-    ///```
+    /// let auth: Authority = Authority::try_from("user:info@foo.com:443").unwrap();
+    /// assert_eq!(auth.host(), "foo.com");
+    /// ```
     pub fn host(&self) -> &str {
         &self.inner[self.host]
     }
 
-    ///Returns port of this `Authority`
+    /// Returns port of this `Authority`
     ///
-    ///# Example
-    ///```
-    ///use http_req::uri::Authority;
-    ///use std::convert::TryFrom;
+    /// # Example
+    /// ```
+    /// use http_req::uri::Authority;
+    /// use std::convert::TryFrom;
     ///
-    ///let auth: Authority = Authority::try_from("user:info@foo.com:443").unwrap();
-    ///assert_eq!(auth.port(), Some(443));
-    ///```
+    /// let auth: Authority = Authority::try_from("user:info@foo.com:443").unwrap();
+    /// assert_eq!(auth.port(), Some(443));
+    /// ```
     pub fn port(&self) -> Option<u16> {
         self.port.as_ref().map(|p| self.inner[*p].parse().unwrap())
     }
@@ -450,14 +450,14 @@ impl<'a> fmt::Display for Authority<'a> {
     }
 }
 
-//Removes whitespace from `text`
+/// Removes whitespace from `text`
 pub fn remove_spaces(text: &mut String) {
     text.retain(|c| !c.is_whitespace());
 }
 
-//Splits `s` by `separator`. If `separator` is found inside `s`, it will return two `Some` values
-//consisting `RangeC` of each `&str`. If `separator` is at the end of `s` or it's not found,
-//it will return tuple consisting `Some` with `RangeC` of entire `s` inside and None.
+/// Splits `s` by `separator`. If `separator` is found inside `s`, it will return two `Some` values
+/// consisting `RangeC` of each `&str`. If `separator` is at the end of `s` or it's not found,
+/// it will return tuple consisting `Some` with `RangeC` of entire `s` inside and None.
 fn get_chunks<'a>(
     s: &'a str,
     range: Option<RangeC>,


### PR DESCRIPTION
### What's new
* Improve memory management and overall stability
    * Fix issue causing all data to be loaded into memory instead of dedicated writer
    * Fix issue that could lead to exceeding timeout when server was sending data at very low speed  #46
    * Ensure that response body is only read when the content-length is greater than 0 or is unknown as per #65 by @ghu
* `Stream` allows to more easily manage TCP connection and perform common operations on the underlying TCP stream
* Update dependencies
    * rustls ^0.23
    * rustls-pemfile ^2.1
    * webpki-roots ^0.26
* New dependencies (for rustls)
    * rustls-pki-types ^ 1.7
### Breaking changes
* `RequestBuilder` can no longer send requests by itself. It is now only used to prepare request messages.
* Default `Request` timeout is set to 1 hour