### PR TITLE
feat: add instrumentation for http calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
+ "tracing",
  "unicase",
  "webpki",
  "webpki-roots",
@@ -363,6 +364,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkg-config"
@@ -577,6 +584,37 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rustls-pemfile = { version = "^2.2", optional = true }
 rustls-pki-types = { version = "^1.13", features = ["alloc"], optional = true }
 webpki = { version = "^0.22", optional = true }
 webpki-roots = { version = "^1.0", optional = true }
+tracing = { version = "^0.1", optional = true }
 
 [features]
 default = ["native-tls", "auth"]
@@ -32,3 +33,4 @@ rust-tls = [
     "auth",
 ]
 auth = ["base64", "zeroize"]
+tracing = ["dep:tracing"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ In order to use `http_req` with `rustls` in your project, add the following line
 http_req = { version="^0.14", default-features = false, features = ["rust-tls"] }
 ```
 
+### Tracing with open telemetry
+
+To be able to add traces to your HTTP requests if you want them in your monitoring system, you can enable the `tracing` feature.
+
+⚠️ You need to have a tracing subscriber set up in your project to be able to see the traces.
+
+In order to enable traces in `http_req` in your project, add the following lines to `Cargo.toml`:
+
+```toml
+[dependencies]
+http_req = { version="^0.14", default-features = false, features = ["tracing"] }
+```
+
 ### HTTP only
 
 In order to use `http_req` without any additional features in your project (no HTTPS, no Authentication), add the following lines to `Cargo.toml`:

--- a/src/request.rs
+++ b/src/request.rs
@@ -20,6 +20,8 @@ use std::{
 };
 #[cfg(feature = "auth")]
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+#[cfg(feature = "tracing")]
+use tracing::Span;
 
 const CR_LF: &str = "\r\n";
 const DEFAULT_REDIRECT_LIMIT: usize = 5;
@@ -828,6 +830,21 @@ impl<'a> Request<'a> {
     where
         T: Write,
     {
+        #[cfg(feature = "tracing")]
+        let span = tracing::info_span!(
+            "http_request",
+            otel.name = %format!("{} {}", self.message.method, self.message.uri.host().unwrap_or("")),
+            otel.kind = "client",
+            http.method = %self.message.method,
+            http.url = %self.message.uri,
+            http.status_code = tracing::field::Empty,
+            http.duration_ms = tracing::field::Empty,
+        );
+        #[cfg(feature = "tracing")]
+        let _guard = span.entered();
+        #[cfg(feature = "tracing")]
+        let start = Instant::now();
+
         // Set up a stream.
         let mut stream = Stream::connect(self.message.uri, self.connect_timeout)?;
         stream.set_read_timeout(self.read_timeout)?;
@@ -868,6 +885,12 @@ impl<'a> Request<'a> {
         raw_response_head.receive(&receiver, deadline)?;
         let response = Response::from_head(&raw_response_head)?;
 
+        #[cfg(feature = "tracing")]
+        {
+            let status: u16 = response.status_code().into();
+            Span::current().record("http.status_code", status as i64);
+        }
+
         if response.status_code().is_redirect() {
             if let Some(location) = response.headers().get("Location") {
                 if self.redirect_policy.follow(&location) {
@@ -877,6 +900,9 @@ impl<'a> Request<'a> {
                     } else {
                         Uri::try_from(raw_uri.as_str())
                     }?;
+
+                    #[cfg(feature = "tracing")]
+                    Span::current().record("http.duration_ms", start.elapsed().as_millis() as i64);
 
                     return Request::new(&uri)
                         .redirect_policy(self.redirect_policy)
@@ -893,6 +919,9 @@ impl<'a> Request<'a> {
         if content_len > 0 {
             writer.receive_all(&receiver, deadline)?;
         }
+
+        #[cfg(feature = "tracing")]
+        Span::current().record("http.duration_ms", start.elapsed().as_millis() as i64);
 
         Ok(response)
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -842,8 +842,6 @@ impl<'a> Request<'a> {
         );
         #[cfg(feature = "tracing")]
         let _guard = span.entered();
-        #[cfg(feature = "tracing")]
-        let start = Instant::now();
 
         // Set up a stream.
         let mut stream = Stream::connect(self.message.uri, self.connect_timeout)?;
@@ -866,6 +864,9 @@ impl<'a> Request<'a> {
         let mut raw_response_head: Vec<u8> = Vec::new();
         let mut buf_reader = BufReader::new(stream);
 
+        #[cfg(feature = "tracing")]
+        let start = Instant::now();
+
         // Read from the stream and send over data via `sender`.
         thread::spawn(move || {
             buf_reader.send_head(&sender);
@@ -887,6 +888,7 @@ impl<'a> Request<'a> {
 
         #[cfg(feature = "tracing")]
         {
+            Span::current().record("http.duration_ms", start.elapsed().as_millis() as i64);
             let status: u16 = response.status_code().into();
             Span::current().record("http.status_code", status as i64);
         }
@@ -900,9 +902,6 @@ impl<'a> Request<'a> {
                     } else {
                         Uri::try_from(raw_uri.as_str())
                     }?;
-
-                    #[cfg(feature = "tracing")]
-                    Span::current().record("http.duration_ms", start.elapsed().as_millis() as i64);
 
                     return Request::new(&uri)
                         .redirect_policy(self.redirect_policy)
@@ -919,9 +918,6 @@ impl<'a> Request<'a> {
         if content_len > 0 {
             writer.receive_all(&receiver, deadline)?;
         }
-
-        #[cfg(feature = "tracing")]
-        Span::current().record("http.duration_ms", start.elapsed().as_millis() as i64);
 
         Ok(response)
     }


### PR DESCRIPTION
Linked to this issue https://github.com/jayjamesjay/http_req/issues/72

I currently adding some monitor in a project and I need to be able to trace http calls I make through http_req crate.

Here I proposed an implementation with a features and tracing crate.

In flame graph: 
<img width="1763" height="45" alt="image" src="https://github.com/user-attachments/assets/9241eb2a-bbba-4c24-85bf-0f2a85ef17b3" />

In details of span: 
<img width="403" height="370" alt="image" src="https://github.com/user-attachments/assets/414d084b-81a1-4276-9b39-0adeb175e6c6" />
